### PR TITLE
v1.3.4 gitlab: fix work-item project path + resilient API + labels UI

### DIFF
--- a/gitter.gitlab.prj/Api/ApiEndpoint.Issues.cs
+++ b/gitter.gitlab.prj/Api/ApiEndpoint.Issues.cs
@@ -1,18 +1,18 @@
-﻿#region Copyright Notice
+#region Copyright Notice
 /*
  * gitter - VCS repository management tool
  * Copyright (C) 2022  Popovskiy Maxim Vladimirovitch <amgine.gitter@gmail.com>
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -23,12 +23,17 @@ namespace gitter.GitLab.Api;
 using System;
 using System.Globalization;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.Threading;
 
 partial class ApiEndpoint
 {
+	public const string NoneFilter = @"None";
+
+	public const string AnyFilter = @"Any";
+
 	private static string StateToString(IssueState state)
 		=> state switch
 		{
@@ -46,43 +51,50 @@ partial class ApiEndpoint
 			_ => throw new ArgumentException($"Unknown scope: {scope}.", nameof(scope)),
 		};
 
+	private static string OrderToString(IssueOrderBy order)
+		=> order switch
+		{
+			IssueOrderBy.CreatedAt        => @"created_at",
+			IssueOrderBy.UpdatedAt        => @"updated_at",
+			IssueOrderBy.Priority         => @"priority",
+			IssueOrderBy.DueDate          => @"due_date",
+			IssueOrderBy.RelativePosition => @"relative_position",
+			IssueOrderBy.LabelPriority    => @"label_priority",
+			IssueOrderBy.MilestoneDue     => @"milestone_due",
+			IssueOrderBy.Popularity       => @"popularity",
+			IssueOrderBy.Weight           => @"weight",
+			IssueOrderBy.Title            => @"title",
+			_ => throw new ArgumentException($"Unknown order: {order}.", nameof(order)),
+		};
+
+	private static string IssueTypeToString(WorkItemType type)
+		=> WorkItemTypes.ToApiString(type)
+		?? throw new ArgumentException($"Unknown work item type: {type}.", nameof(type));
+
+	private static string EncodeFilterValue(string value)
+		=> value is NoneFilter or AnyFilter ? value : Uri.EscapeDataString(value);
+
 	public Task<IReadOnlyList<Issue>> GetProjectIssuesAsync(
 		NameOrNumericId projectId,
-		IssueState? state      = default,
-		IssueScope? scope      = default,
-		long?       assigneeId = default,
-		long?       authorId   = default,
-		SortOrder?  sort       = default,
-		System.Collections.Generic.IReadOnlyCollection<string>? labels = default,
-		string?     milestone  = default,
+		IssueState?     state         = default,
+		IssueScope?     scope         = default,
+		WorkItemType?   issueType     = default,
+		long?           assigneeId    = default,
+		long?           authorId      = default,
+		IssueOrderBy?   orderBy       = default,
+		SortOrder?      sort          = default,
+		IReadOnlyCollection<string>? labels = default,
+		string?         milestone     = default,
+		string?         search        = default,
+		IReadOnlyCollection<long>? iids = default,
+		DateTimeOffset? createdAfter  = default,
+		DateTimeOffset? createdBefore = default,
+		DateTimeOffset? updatedAfter  = default,
+		DateTimeOffset? updatedBefore = default,
+		bool?           confidential  = default,
+		bool            withLabelsDetails = false,
 		CancellationToken cancellationToken = default)
 	{
-		/*
-		author_username
-		confidential
-		created_after
-		created_before
-		due_date
-		epic_id
-		iids[]
-		in
-		issue_type
-		iteration_id
-		iteration_title
-		labels
-		milestone
-		milestone_id
-		my_reaction_emoji
-		non_archived
-		not
-		order_by
-		search
-		updated_after
-		updated_before
-		weight
-		with_labels_details
-		 */
-
 		var query = new StringBuilder();
 		AppendProjectUrl(query, projectId, @"issues");
 
@@ -92,15 +104,38 @@ partial class ApiEndpoint
 		if(authorId.HasValue)   AppendParameter(query, ref sep, @"author_id",   authorId.Value.ToString(CultureInfo.InvariantCulture));
 		if(state.HasValue)      AppendParameter(query, ref sep, @"state",       StateToString(state.Value));
 		if(scope.HasValue)      AppendParameter(query, ref sep, @"scope",       ScopeToString(scope.Value));
+		if(issueType.HasValue)  AppendParameter(query, ref sep, @"issue_type",  IssueTypeToString(issueType.Value));
+		if(orderBy.HasValue)    AppendParameter(query, ref sep, @"order_by",    OrderToString(orderBy.Value));
 		if(sort.HasValue)       AppendParameter(query, ref sep, @"sort",        SortToString(sort.Value));
+
 		if(labels is { Count: > 0 })
 		{
-			AppendParameter(query, ref sep, @"labels", string.Join(",", System.Linq.Enumerable.Select(labels, System.Uri.EscapeDataString)));
+			AppendParameter(query, ref sep, @"labels",
+				string.Join(",", labels.Select(EncodeFilterValue)));
 		}
 		if(!string.IsNullOrEmpty(milestone))
 		{
-			AppendParameter(query, ref sep, @"milestone", System.Uri.EscapeDataString(milestone!));
+			AppendParameter(query, ref sep, @"milestone", EncodeFilterValue(milestone!));
 		}
+		if(!string.IsNullOrEmpty(search))
+		{
+			AppendParameter(query, ref sep, @"search", Uri.EscapeDataString(search!));
+		}
+		if(iids is { Count: > 0 })
+		{
+			foreach(var iid in iids)
+			{
+				AppendParameter(query, ref sep, @"iids[]", iid.ToString(CultureInfo.InvariantCulture));
+			}
+		}
+
+		if(createdAfter.HasValue)  AppendParameter(query, ref sep, @"created_after",  Uri.EscapeDataString(DateTimeHelper.FormatISO8601(createdAfter.Value)));
+		if(createdBefore.HasValue) AppendParameter(query, ref sep, @"created_before", Uri.EscapeDataString(DateTimeHelper.FormatISO8601(createdBefore.Value)));
+		if(updatedAfter.HasValue)  AppendParameter(query, ref sep, @"updated_after",  Uri.EscapeDataString(DateTimeHelper.FormatISO8601(updatedAfter.Value)));
+		if(updatedBefore.HasValue) AppendParameter(query, ref sep, @"updated_before", Uri.EscapeDataString(DateTimeHelper.FormatISO8601(updatedBefore.Value)));
+
+		if(confidential.HasValue)  AppendParameter(query, ref sep, @"confidential", confidential.Value ? @"true" : @"false");
+		if(withLabelsDetails)      AppendParameter(query, ref sep, @"with_labels_details", @"true");
 
 		return ReadPagedResultAsync<Issue>(query.ToString(), cancellationToken);
 	}

--- a/gitter.gitlab.prj/Api/ApiEndpoint.cs
+++ b/gitter.gitlab.prj/Api/ApiEndpoint.cs
@@ -22,6 +22,7 @@ namespace gitter.GitLab.Api;
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Net.Http;
 using System.Net.Http.Headers;
@@ -39,30 +40,64 @@ using gitter.Framework;
 
 partial class ApiEndpoint
 {
+	private const int PageSize = 100;
+
 	private static string? GetNextPageUrl(HttpResponseHeaders headers)
 	{
 		Assert.IsNotNull(headers);
 
-		if(headers.TryGetValues("Link", out var links))
+		if(!headers.TryGetValues("Link", out var links)) return default;
+
+		foreach(var link in links)
 		{
-			foreach(var link in links)
+			if(string.IsNullOrWhiteSpace(link)) continue;
+
+			var pos = 0;
+			while(pos < link.Length)
 			{
-				if(string.IsNullOrWhiteSpace(link)) continue;
-				foreach(var part in link.Split(','))
+				var s = link.IndexOf('<', pos);
+				if(s < 0) break;
+				var e = link.IndexOf('>', s + 1);
+				if(e < 0) break;
+
+				var next      = link.IndexOf('<', e + 1);
+				var paramsEnd = next < 0 ? link.Length : next;
+
+				if(IsRelNext(link.Substring(e + 1, paramsEnd - e - 1)))
 				{
-					if(part.EndsWith("rel=\"next\""))
-					{
-						var s = part.IndexOf('<');
-						var e = part.IndexOf('>');
-						if(s >= 0 && e > s)
-						{
-							return part.Substring(s + 1, e - s - 1);
-						}
-					}
+					return link.Substring(s + 1, e - s - 1);
 				}
+				pos = paramsEnd;
 			}
 		}
 		return default;
+	}
+
+	private static bool IsRelNext(string parameters)
+	{
+		foreach(var part in parameters.Split(';'))
+		{
+			var p = part.Trim().TrimEnd(',').Trim();
+			var eq = p.IndexOf('=');
+			if(eq <= 0) continue;
+			if(!p.Substring(0, eq).Trim().Equals(@"rel", StringComparison.OrdinalIgnoreCase)) continue;
+
+			var value = p.Substring(eq + 1).Trim().Trim('"', '\'');
+			foreach(var token in value.Split(' '))
+			{
+				if(token.Equals(@"next", StringComparison.OrdinalIgnoreCase)) return true;
+			}
+		}
+		return false;
+	}
+
+	private static string EnsurePageSize(string url)
+	{
+		Assert.IsNeitherNullNorWhitespace(url);
+
+		if(url.IndexOf(@"per_page=", StringComparison.OrdinalIgnoreCase) >= 0) return url;
+
+		return url + (url.IndexOf('?') >= 0 ? '&' : '?') + @"per_page=" + PageSize.ToString(CultureInfo.InvariantCulture);
 	}
 
 	private static async Task<T?> ReadReponseAsync<T>(HttpResponseMessage response, CancellationToken cancellationToken = default)
@@ -92,7 +127,7 @@ partial class ApiEndpoint
 		Assert.IsNeitherNullNorWhitespace(url);
 
 		var result = default(List<T>);
-		string? next = url;
+		string? next = EnsurePageSize(url);
 		while(true)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
@@ -103,7 +138,8 @@ partial class ApiEndpoint
 				.SendAsync(message, cancellationToken)
 				.ConfigureAwait(continueOnCapturedContext: false);
 
-			response.EnsureSuccessStatusCode();
+			await CheckResponseAsync(response, cancellationToken)
+				.ConfigureAwait(continueOnCapturedContext: false);
 
 			var page = await ReadReponseAsync<T[]>(response, cancellationToken)
 				.ConfigureAwait(continueOnCapturedContext: false);
@@ -124,15 +160,60 @@ partial class ApiEndpoint
 		return result ?? (IReadOnlyList<T>)Preallocated<T>.EmptyArray;
 	}
 
-	private static void CheckResponse(HttpResponseMessage response)
+	private static async Task CheckResponseAsync(HttpResponseMessage response, CancellationToken cancellationToken = default)
 	{
+		Assert.IsNotNull(response);
+
 		if(response.IsSuccessStatusCode) return;
 
-		if(response.StatusCode == System.Net.HttpStatusCode.Unauthorized)
+		var details = await ReadErrorMessageAsync(response, cancellationToken)
+			.ConfigureAwait(continueOnCapturedContext: false);
+
+		throw GitLabApiException.Create(response, details);
+	}
+
+	private static async Task<string?> ReadErrorMessageAsync(HttpResponseMessage response, CancellationToken cancellationToken)
+	{
+		string body;
+		try
 		{
-			throw new UnauthorizedAccessException();
+			body = await response.Content
+				.ReadAsStringAsync(cancellationToken)
+				.ConfigureAwait(continueOnCapturedContext: false);
 		}
-		response.EnsureSuccessStatusCode();
+		catch(OperationCanceledException)
+		{
+			throw;
+		}
+		catch
+		{
+			return default;
+		}
+
+		if(string.IsNullOrWhiteSpace(body)) return default;
+
+#if SYSTEM_TEXT_JSON
+		try
+		{
+			using var document = JsonDocument.Parse(body);
+			if(document.RootElement.ValueKind == JsonValueKind.Object)
+			{
+				foreach(var name in new[] { @"message", @"error", @"error_description" })
+				{
+					if(document.RootElement.TryGetProperty(name, out var value))
+					{
+						return value.ValueKind == JsonValueKind.String ? value.GetString() : value.ToString();
+					}
+				}
+			}
+		}
+		catch(JsonException)
+		{
+		}
+#endif
+
+		body = body.Trim();
+		return body.Length > 512 ? body.Substring(0, 512) : body;
 	}
 
 	private async Task<T?> GetAsync<T>(string url, CancellationToken cancellationToken = default)
@@ -145,7 +226,8 @@ partial class ApiEndpoint
 			.SendAsync(message, cancellationToken)
 			.ConfigureAwait(continueOnCapturedContext: false);
 
-		CheckResponse(response);
+		await CheckResponseAsync(response, cancellationToken)
+			.ConfigureAwait(continueOnCapturedContext: false);
 
 		return await ReadReponseAsync<T>(response, cancellationToken)
 			.ConfigureAwait(continueOnCapturedContext: false);
@@ -161,7 +243,8 @@ partial class ApiEndpoint
 			.SendAsync(message, cancellationToken)
 			.ConfigureAwait(continueOnCapturedContext: false);
 
-		CheckResponse(response);
+		await CheckResponseAsync(response, cancellationToken)
+			.ConfigureAwait(continueOnCapturedContext: false);
 
 		return await ReadReponseAsync<T>(response, cancellationToken)
 			.ConfigureAwait(continueOnCapturedContext: false);
@@ -173,7 +256,9 @@ partial class ApiEndpoint
 		using var response = await HttpMessageInvoker
 			.SendAsync(request, cancellationToken)
 			.ConfigureAwait(continueOnCapturedContext: false);
-		response.EnsureSuccessStatusCode();
+
+		await CheckResponseAsync(response, cancellationToken)
+			.ConfigureAwait(continueOnCapturedContext: false);
 	}
 
 	public ApiEndpoint(HttpMessageInvoker httpMessageInvoker, ServerInfo server)

--- a/gitter.gitlab.prj/Api/Assignee.cs
+++ b/gitter.gitlab.prj/Api/Assignee.cs
@@ -41,7 +41,7 @@ public sealed class Assignee
 
 	[DataMember]
 	[JsonPropertyName(Names.Id)]
-	public int Id { get; set; } = default!;
+	public long Id { get; set; } = default!;
 
 	[DataMember]
 	[JsonPropertyName(Names.State)]

--- a/gitter.gitlab.prj/Api/GitLabApiException.cs
+++ b/gitter.gitlab.prj/Api/GitLabApiException.cs
@@ -1,0 +1,89 @@
+#region Copyright Notice
+/*
+ * gitter - VCS repository management tool
+ * Copyright (C) 2026  Popovskiy Maxim Vladimirovitch <amgine.gitter@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#endregion
+
+namespace gitter.GitLab.Api;
+
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+
+class GitLabApiException : Exception
+{
+	public static Exception Create(HttpResponseMessage response, string? details)
+	{
+		Assert.IsNotNull(response);
+
+		var url     = response.RequestMessage?.RequestUri?.ToString();
+		var message = FormatMessage(response.StatusCode, response.ReasonPhrase, url, details);
+
+		return response.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden
+			? new GitLabUnauthorizedException(message, response.StatusCode, url, details)
+			: new GitLabApiException(message, response.StatusCode, url, details);
+	}
+
+	private static string FormatMessage(HttpStatusCode statusCode, string? reasonPhrase, string? url, string? details)
+	{
+		var sb = new StringBuilder();
+		sb.Append("GitLab API request failed: ");
+		sb.Append((int)statusCode);
+		if(!string.IsNullOrWhiteSpace(reasonPhrase))
+		{
+			sb.Append(' ');
+			sb.Append(reasonPhrase);
+		}
+		if(!string.IsNullOrWhiteSpace(details))
+		{
+			sb.Append(" - ");
+			sb.Append(details);
+		}
+		if(!string.IsNullOrWhiteSpace(url))
+		{
+			sb.Append(" [");
+			sb.Append(url);
+			sb.Append(']');
+		}
+		return sb.ToString();
+	}
+
+	public GitLabApiException(string message, HttpStatusCode statusCode, string? url, string? details)
+		: base(message)
+	{
+		StatusCode = statusCode;
+		Url        = url;
+		Details    = details;
+	}
+
+	public HttpStatusCode StatusCode { get; }
+
+	public string? Url { get; }
+
+	public string? Details { get; }
+}
+
+sealed class GitLabUnauthorizedException(string message, HttpStatusCode statusCode, string? url, string? details)
+	: UnauthorizedAccessException(message)
+{
+	public HttpStatusCode StatusCode { get; } = statusCode;
+
+	public string? Url { get; } = url;
+
+	public string? Details { get; } = details;
+}

--- a/gitter.gitlab.prj/Api/Issue.cs
+++ b/gitter.gitlab.prj/Api/Issue.cs
@@ -46,6 +46,13 @@ sealed class Issue : ModifiableObject
 		public const string Weight         = @"weight";
 		public const string TimeStats      = @"time_stats";
 		public const string TaskCompletionStatus = @"task_completion_status";
+		public const string IssueType      = @"issue_type";
+		public const string Type           = @"type";
+		public const string Severity       = @"severity";
+		public const string HealthStatus   = @"health_status";
+		public const string References     = @"references";
+		public const string DiscussionLocked = @"discussion_locked";
+		public const string MergeRequestsCount = @"merge_requests_count";
 	}
 
 	[DataMember]
@@ -119,4 +126,35 @@ sealed class Issue : ModifiableObject
 	[DataMember]
 	[JsonPropertyName(Names.TaskCompletionStatus)]
 	public IssueTaskCompletionStatus? TaskCompletionStatus { get; set; }
+
+	[DataMember]
+	[JsonPropertyName(Names.IssueType)]
+	public WorkItemType IssueType { get; set; }
+
+	[DataMember]
+	[JsonPropertyName(Names.Type)]
+	public WorkItemType Type { get; set; }
+
+	[DataMember]
+	[JsonPropertyName(Names.Severity)]
+	public string? Severity { get; set; }
+
+	[DataMember]
+	[JsonPropertyName(Names.HealthStatus)]
+	public string? HealthStatus { get; set; }
+
+	[DataMember]
+	[JsonPropertyName(Names.References)]
+	public IssueReferences? References { get; set; }
+
+	[DataMember]
+	[JsonPropertyName(Names.DiscussionLocked)]
+	public bool? DiscussionLocked { get; set; }
+
+	[DataMember]
+	[JsonPropertyName(Names.MergeRequestsCount)]
+	public int MergeRequestsCount { get; set; }
+
+	public WorkItemType EffectiveType
+		=> IssueType != WorkItemType.Unknown ? IssueType : Type;
 }

--- a/gitter.gitlab.prj/Api/IssueOrderBy.cs
+++ b/gitter.gitlab.prj/Api/IssueOrderBy.cs
@@ -1,0 +1,35 @@
+#region Copyright Notice
+/*
+ * gitter - VCS repository management tool
+ * Copyright (C) 2026  Popovskiy Maxim Vladimirovitch <amgine.gitter@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#endregion
+
+namespace gitter.GitLab.Api;
+
+enum IssueOrderBy
+{
+	CreatedAt,
+	UpdatedAt,
+	Priority,
+	DueDate,
+	RelativePosition,
+	LabelPriority,
+	MilestoneDue,
+	Popularity,
+	Weight,
+	Title,
+}

--- a/gitter.gitlab.prj/Api/IssueReferences.cs
+++ b/gitter.gitlab.prj/Api/IssueReferences.cs
@@ -1,0 +1,48 @@
+#region Copyright Notice
+/*
+ * gitter - VCS repository management tool
+ * Copyright (C) 2026  Popovskiy Maxim Vladimirovitch <amgine.gitter@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#endregion
+
+namespace gitter.GitLab.Api;
+
+using System.Runtime.Serialization;
+
+[DataContract]
+sealed class IssueReferences
+{
+	static class Names
+	{
+		public const string Short    = @"short";
+		public const string Relative = @"relative";
+		public const string Full     = @"full";
+	}
+
+	[DataMember]
+	[JsonPropertyName(Names.Short)]
+	public string? Short { get; set; }
+
+	[DataMember]
+	[JsonPropertyName(Names.Relative)]
+	public string? Relative { get; set; }
+
+	[DataMember]
+	[JsonPropertyName(Names.Full)]
+	public string? Full { get; set; }
+
+	public override string ToString() => Full ?? Relative ?? Short ?? string.Empty;
+}

--- a/gitter.gitlab.prj/Api/IssueState.cs
+++ b/gitter.gitlab.prj/Api/IssueState.cs
@@ -1,18 +1,18 @@
-﻿#region Copyright Notice
+#region Copyright Notice
 /*
  * gitter - VCS repository management tool
  * Copyright (C) 2020  Popovskiy Maxim Vladimirovitch <amgine.gitter@gmail.com>
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -20,18 +20,53 @@
 
 namespace gitter.GitLab.Api;
 
+using System;
 using System.Runtime.Serialization;
 #if SYSTEM_TEXT_JSON
+using System.Text.Json;
 using System.Text.Json.Serialization;
 #endif
 
 #if SYSTEM_TEXT_JSON
-[JsonConverter(typeof(JsonStringEnumConverter))]
+[JsonConverter(typeof(IssueStateConverter))]
 #endif
 enum IssueState
 {
+	Unknown = 0,
+
 	[EnumMember(Value = @"opened")]
 	Opened,
+
 	[EnumMember(Value = @"closed")]
 	Closed,
 }
+
+#if SYSTEM_TEXT_JSON
+
+sealed class IssueStateConverter : JsonConverter<IssueState>
+{
+	public override IssueState Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+	{
+		if(reader.TokenType != JsonTokenType.String) return IssueState.Unknown;
+
+		return reader.GetString()?.Trim().ToLowerInvariant() switch
+		{
+			@"opened"   => IssueState.Opened,
+			@"reopened" => IssueState.Opened,
+			@"closed"   => IssueState.Closed,
+			_ => IssueState.Unknown,
+		};
+	}
+
+	public override void Write(Utf8JsonWriter writer, IssueState value, JsonSerializerOptions options)
+	{
+		switch(value)
+		{
+			case IssueState.Opened: writer.WriteStringValue(@"opened"); break;
+			case IssueState.Closed: writer.WriteStringValue(@"closed"); break;
+			default: writer.WriteNullValue(); break;
+		}
+	}
+}
+
+#endif

--- a/gitter.gitlab.prj/Api/MilestoneState.cs
+++ b/gitter.gitlab.prj/Api/MilestoneState.cs
@@ -1,18 +1,18 @@
-﻿#region Copyright Notice
+#region Copyright Notice
 /*
  * gitter - VCS repository management tool
  * Copyright (C) 2020  Popovskiy Maxim Vladimirovitch <amgine.gitter@gmail.com>
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -20,19 +20,57 @@
 
 namespace gitter.GitLab.Api;
 
+using System;
 using System.Runtime.Serialization;
 #if SYSTEM_TEXT_JSON
+using System.Text.Json;
 using System.Text.Json.Serialization;
 #endif
 
 #if SYSTEM_TEXT_JSON
-[JsonConverter(typeof(JsonStringEnumConverter))]
+[JsonConverter(typeof(MilestoneStateConverter))]
 #endif
 enum MilestoneState
 {
+	Unknown = 0,
+
 	[EnumMember(Value = @"active")]
 	Active,
+
 	[EnumMember(Value = @"closed")]
 	Closed,
-	All
+
+	All,
 }
+
+#if SYSTEM_TEXT_JSON
+
+sealed class MilestoneStateConverter : JsonConverter<MilestoneState>
+{
+	public override MilestoneState Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+	{
+		if(reader.TokenType != JsonTokenType.String) return MilestoneState.Unknown;
+
+		return reader.GetString()?.Trim().ToLowerInvariant() switch
+		{
+			@"active"  => MilestoneState.Active,
+			@"closed"  => MilestoneState.Closed,
+			@"expired" => MilestoneState.Closed,
+			@"all"     => MilestoneState.All,
+			_ => MilestoneState.Unknown,
+		};
+	}
+
+	public override void Write(Utf8JsonWriter writer, MilestoneState value, JsonSerializerOptions options)
+	{
+		switch(value)
+		{
+			case MilestoneState.Active: writer.WriteStringValue(@"active"); break;
+			case MilestoneState.Closed: writer.WriteStringValue(@"closed"); break;
+			case MilestoneState.All:    writer.WriteStringValue(@"all");    break;
+			default: writer.WriteNullValue(); break;
+		}
+	}
+}
+
+#endif

--- a/gitter.gitlab.prj/Api/ModifiableObject.cs
+++ b/gitter.gitlab.prj/Api/ModifiableObject.cs
@@ -36,11 +36,11 @@ class ModifiableObject
 
 	[DataMember]
 	[JsonPropertyName(Names.Iid)]
-	public int Iid { get; set; }
+	public long Iid { get; set; }
 
 	[DataMember]
 	[JsonPropertyName(Names.Id)]
-	public int Id { get; set; }
+	public long Id { get; set; }
 
 	[DataMember]
 	[JsonPropertyName(Names.CreatedAt)]

--- a/gitter.gitlab.prj/Api/WorkItemType.cs
+++ b/gitter.gitlab.prj/Api/WorkItemType.cs
@@ -1,0 +1,131 @@
+#region Copyright Notice
+/*
+ * gitter - VCS repository management tool
+ * Copyright (C) 2026  Popovskiy Maxim Vladimirovitch <amgine.gitter@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#endregion
+
+namespace gitter.GitLab.Api;
+
+using System;
+using System.Runtime.Serialization;
+
+#if SYSTEM_TEXT_JSON
+using System.Text.Json;
+using System.Text.Json.Serialization;
+#endif
+
+#if SYSTEM_TEXT_JSON
+[JsonConverter(typeof(WorkItemTypeConverter))]
+#endif
+enum WorkItemType
+{
+	Unknown = 0,
+
+	[EnumMember(Value = @"issue")]
+	Issue,
+
+	[EnumMember(Value = @"incident")]
+	Incident,
+
+	[EnumMember(Value = @"test_case")]
+	TestCase,
+
+	[EnumMember(Value = @"task")]
+	Task,
+
+	[EnumMember(Value = @"requirement")]
+	Requirement,
+
+	[EnumMember(Value = @"objective")]
+	Objective,
+
+	[EnumMember(Value = @"key_result")]
+	KeyResult,
+
+	[EnumMember(Value = @"epic")]
+	Epic,
+
+	[EnumMember(Value = @"ticket")]
+	Ticket,
+}
+
+static class WorkItemTypes
+{
+	public static readonly WorkItemType[] Filterable =
+	[
+		WorkItemType.Issue,
+		WorkItemType.Incident,
+		WorkItemType.TestCase,
+		WorkItemType.Task,
+	];
+
+	public static string? ToApiString(WorkItemType value)
+		=> value switch
+		{
+			WorkItemType.Issue       => @"issue",
+			WorkItemType.Incident    => @"incident",
+			WorkItemType.TestCase    => @"test_case",
+			WorkItemType.Task        => @"task",
+			WorkItemType.Requirement => @"requirement",
+			WorkItemType.Objective   => @"objective",
+			WorkItemType.KeyResult   => @"key_result",
+			WorkItemType.Epic        => @"epic",
+			WorkItemType.Ticket      => @"ticket",
+			_ => default,
+		};
+
+	public static WorkItemType Parse(string? value)
+	{
+		if(string.IsNullOrWhiteSpace(value)) return WorkItemType.Unknown;
+
+		return value!.Trim().Replace("_", "").Replace("-", "").ToLowerInvariant() switch
+		{
+			@"issue"       => WorkItemType.Issue,
+			@"incident"    => WorkItemType.Incident,
+			@"testcase"    => WorkItemType.TestCase,
+			@"task"        => WorkItemType.Task,
+			@"requirement" => WorkItemType.Requirement,
+			@"objective"   => WorkItemType.Objective,
+			@"keyresult"   => WorkItemType.KeyResult,
+			@"epic"        => WorkItemType.Epic,
+			@"ticket"      => WorkItemType.Ticket,
+			_ => WorkItemType.Unknown,
+		};
+	}
+}
+
+#if SYSTEM_TEXT_JSON
+
+sealed class WorkItemTypeConverter : JsonConverter<WorkItemType>
+{
+	public override WorkItemType Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		=> reader.TokenType switch
+		{
+			JsonTokenType.String => WorkItemTypes.Parse(reader.GetString()),
+			JsonTokenType.Null   => WorkItemType.Unknown,
+			_ => WorkItemType.Unknown,
+		};
+
+	public override void Write(Utf8JsonWriter writer, WorkItemType value, JsonSerializerOptions options)
+	{
+		var str = WorkItemTypes.ToApiString(value);
+		if(str is null) writer.WriteNullValue();
+		else            writer.WriteStringValue(str);
+	}
+}
+
+#endif

--- a/gitter.gitlab.prj/Dialogs/AddServerDialog.cs
+++ b/gitter.gitlab.prj/Dialogs/AddServerDialog.cs
@@ -46,6 +46,8 @@ partial class AddServerDialog : DialogBase, IAsyncExecutableDialog, IAddServerVi
 		public  readonly TextBox _txtServiceUrl;
 		public  readonly TextBox _txtAPIKey;
 		public  readonly LinkLabel _lnkTokens;
+		public  readonly PictureBox _picCopyTokensUrl;
+		private readonly ToolTip _toolTip;
 
 		public DialogControls()
 		{
@@ -65,6 +67,16 @@ partial class AddServerDialog : DialogBase, IAsyncExecutableDialog, IAddServerVi
 			};
 			_lnkTokens.Links[0].Enabled = false;
 
+			_picCopyTokensUrl = new()
+			{
+				SizeMode = PictureBoxSizeMode.CenterImage,
+				Cursor   = Cursors.Hand,
+				Margin   = Padding.Empty,
+				Enabled  = false,
+				TabStop  = false,
+			};
+			_toolTip = new();
+
 			GitterApplication.FontManager.InputFont.Apply(_txtName, _txtServiceUrl, _txtAPIKey);
 		}
 
@@ -74,6 +86,7 @@ partial class AddServerDialog : DialogBase, IAsyncExecutableDialog, IAddServerVi
 			_lblAPIKey.Text     = Resources.StrAPIKey.AddColon();
 			_lblServiceUrl.Text = Resources.StrServiceUri.AddColon();
 			_lnkTokens.Text     = Resources.StrsManageAccessTokens;
+			_toolTip.SetToolTip(_picCopyTokensUrl, Resources.StrsCopyAccessTokensUrl);
 		}
 
 		public void Layout(Control parent)
@@ -106,7 +119,22 @@ partial class AddServerDialog : DialogBase, IAsyncExecutableDialog, IAddServerVi
 						new GridContent(new ControlContent(urlDec,         marginOverride: LayoutConstants.TextBoxMargin), row: 1, column: 1),
 						new GridContent(new ControlContent(_lblAPIKey,     marginOverride: LayoutConstants.NoMargin), row: 2),
 						new GridContent(new ControlContent(keyDec,         marginOverride: LayoutConstants.TextBoxMargin), row: 2, column: 1),
-						new GridContent(new ControlContent(_lnkTokens,     marginOverride: DpiBoundValue.Padding(new(-3, 0, 0, 0))), row: 3, column: 1),
+						new GridContent(new Grid(
+							columns:
+							[
+								SizeSpec.Absolute(20),
+								SizeSpec.Everything(),
+							],
+							content:
+							[
+								new GridContent(new ControlContent(_picCopyTokensUrl,
+									sizeOverride:               DpiBoundValue.Size(new(16, 16)),
+									marginOverride:             LayoutConstants.NoMargin,
+									horizontalContentAlignment: HorizontalContentAlignment.Left,
+									verticalContentAlignment:   VerticalContentAlignment.Center), column: 0),
+								new GridContent(new ControlContent(_lnkTokens,
+									marginOverride: LayoutConstants.NoMargin), column: 1),
+							]), row: 3, column: 1),
 					]),
 			};
 
@@ -126,6 +154,7 @@ partial class AddServerDialog : DialogBase, IAsyncExecutableDialog, IAddServerVi
 			_lblAPIKey.Parent = parent;
 			keyDec.Parent = parent;
 			_lnkTokens.Parent = parent;
+			_picCopyTokensUrl.Parent = parent;
 		}
 	}
 
@@ -157,10 +186,24 @@ partial class AddServerDialog : DialogBase, IAsyncExecutableDialog, IAddServerVi
 		};
 		UserInputErrorNotifier = new UserInputErrorNotifier(NotificationService, inputs);
 
+		var dpiBindings = new DpiBindings(this);
+		dpiBindings.BindImage(_controls._picCopyTokensUrl, CommonIcons.ClipboardCopy);
+
 		_controls._lnkTokens.LinkClicked += OnManageAccessTokensClick;
-		_controls._txtServiceUrl.TextChanged += (_, _) => _controls._lnkTokens.Links[0].Enabled = _controls._txtServiceUrl.TextLength != 0;
+		_controls._picCopyTokensUrl.Click += OnCopyAccessTokensUrlClick;
+		_controls._txtServiceUrl.TextChanged += (_, _) => UpdateAccessTokensLinkState();
+		UpdateAccessTokensLinkState();
 
 		Controller = new AddServerController(httpMessageInvoker, servers) { View = this, };
+	}
+
+	private void UpdateAccessTokensLinkState()
+	{
+		var enabled = _controls._txtServiceUrl.TextLength != 0;
+		_controls._lnkTokens.Links[0].Enabled = enabled;
+
+		_controls._picCopyTokensUrl.Enabled = enabled;
+		_controls._picCopyTokensUrl.Visible = enabled;
 	}
 
 	/// <inheritdoc/>
@@ -191,6 +234,9 @@ partial class AddServerDialog : DialogBase, IAsyncExecutableDialog, IAddServerVi
 
 	private void OnManageAccessTokensClick(object? sender, LinkLabelLinkClickedEventArgs e)
 		=> UrlHelper.OpenPersonalAccessTokensPage(_controls._txtServiceUrl.Text.Trim());
+
+	private void OnCopyAccessTokensUrlClick(object? sender, EventArgs e)
+		=> UrlHelper.CopyPersonalAccessTokensUrl(_controls._txtServiceUrl.Text);
 
 	/// <inheritdoc/>
 	public async Task<bool> ExecuteAsync()

--- a/gitter.gitlab.prj/Dialogs/SetApiKeyDialog.cs
+++ b/gitter.gitlab.prj/Dialogs/SetApiKeyDialog.cs
@@ -42,6 +42,8 @@ partial class SetApiKeyDialog : DialogBase, IAsyncExecutableDialog, ISetApiKeyVi
 		private readonly LabelControl _lblAPIKey;
 		public  readonly TextBox _txtAPIKey;
 		public  readonly LinkLabel _lnkTokens;
+		public  readonly PictureBox _picCopyTokensUrl;
+		private readonly ToolTip _toolTip;
 
 		public DialogControls()
 		{
@@ -56,6 +58,15 @@ partial class SetApiKeyDialog : DialogBase, IAsyncExecutableDialog, ISetApiKeyVi
 				Padding = default,
 			};
 
+			_picCopyTokensUrl = new()
+			{
+				SizeMode = PictureBoxSizeMode.CenterImage,
+				Cursor   = Cursors.Hand,
+				Margin   = Padding.Empty,
+				TabStop  = false,
+			};
+			_toolTip = new();
+
 			GitterApplication.FontManager.InputFont.Apply(_txtAPIKey);
 		}
 
@@ -63,6 +74,7 @@ partial class SetApiKeyDialog : DialogBase, IAsyncExecutableDialog, ISetApiKeyVi
 		{
 			_lblAPIKey.Text = Resources.StrAPIKey.AddColon();
 			_lnkTokens.Text = Resources.StrsManageAccessTokens;
+			_toolTip.SetToolTip(_picCopyTokensUrl, Resources.StrsCopyAccessTokensUrl);
 		}
 
 		public void Layout(Control parent)
@@ -87,7 +99,22 @@ partial class SetApiKeyDialog : DialogBase, IAsyncExecutableDialog, ISetApiKeyVi
 					[
 						new GridContent(new ControlContent(_lblAPIKey, marginOverride: LayoutConstants.NoMargin), row: 0),
 						new GridContent(new ControlContent(keyDec,     marginOverride: LayoutConstants.TextBoxMargin), row: 0, column: 1),
-						new GridContent(new ControlContent(_lnkTokens, marginOverride: DpiBoundValue.Padding(new(-3, 0, 0, 0))), row: 1, column: 1),
+						new GridContent(new Grid(
+							columns:
+							[
+								SizeSpec.Absolute(20),
+								SizeSpec.Everything(),
+							],
+							content:
+							[
+								new GridContent(new ControlContent(_picCopyTokensUrl,
+									sizeOverride:               DpiBoundValue.Size(new(16, 16)),
+									marginOverride:             LayoutConstants.NoMargin,
+									horizontalContentAlignment: HorizontalContentAlignment.Left,
+									verticalContentAlignment:   VerticalContentAlignment.Center), column: 0),
+								new GridContent(new ControlContent(_lnkTokens,
+									marginOverride: LayoutConstants.NoMargin), column: 1),
+							]), row: 1, column: 1),
 					]),
 			};
 
@@ -99,6 +126,7 @@ partial class SetApiKeyDialog : DialogBase, IAsyncExecutableDialog, ISetApiKeyVi
 			_lblAPIKey.Parent = parent;
 			keyDec.Parent     = parent;
 			_lnkTokens.Parent = parent;
+			_picCopyTokensUrl.Parent = parent;
 		}
 	}
 
@@ -131,7 +159,11 @@ partial class SetApiKeyDialog : DialogBase, IAsyncExecutableDialog, ISetApiKeyVi
 		};
 		UserInputErrorNotifier = new UserInputErrorNotifier(NotificationService, inputs);
 
-		_controls._lnkTokens.LinkClicked += OnManageAccessTokensClick;
+		var dpiBindings = new DpiBindings(this);
+		dpiBindings.BindImage(_controls._picCopyTokensUrl, CommonIcons.ClipboardCopy);
+
+		_controls._lnkTokens.LinkClicked  += OnManageAccessTokensClick;
+		_controls._picCopyTokensUrl.Click += OnCopyAccessTokensUrlClick;
 
 		Controller = new SetApiKeyController(httpMessageInvoker, servers) { View = this, };
 	}
@@ -159,6 +191,9 @@ partial class SetApiKeyDialog : DialogBase, IAsyncExecutableDialog, ISetApiKeyVi
 
 	private void OnManageAccessTokensClick(object? sender, LinkLabelLinkClickedEventArgs e)
 		=> UrlHelper.OpenPersonalAccessTokensPage(ServiceUri.ToString());
+
+	private void OnCopyAccessTokensUrlClick(object? sender, EventArgs e)
+		=> UrlHelper.CopyPersonalAccessTokensUrl(ServiceUri.ToString());
 
 	/// <inheritdoc/>
 	public async Task<bool> ExecuteAsync()

--- a/gitter.gitlab.prj/Dialogs/UrlHelper.cs
+++ b/gitter.gitlab.prj/Dialogs/UrlHelper.cs
@@ -24,9 +24,11 @@ using gitter.Framework;
 
 static class UrlHelper
 {
-	static string? GetPersonalAccessTokensUrl(string? url)
+	public static string? GetPersonalAccessTokensUrl(string? url)
 	{
 		if(url is not { Length: not 0 }) return default;
+
+		url = url.Trim();
 		if(!url.StartsWith("http://") && !url.StartsWith("https://")) return default;
 
 		return url.EndsWith('/')
@@ -39,6 +41,14 @@ static class UrlHelper
 		var url = GetPersonalAccessTokensUrl(serviceUrl);
 		if(url is null) return false;
 		Utility.OpenUrl(url);
+		return true;
+	}
+
+	public static bool CopyPersonalAccessTokensUrl(string? serviceUrl)
+	{
+		var url = GetPersonalAccessTokensUrl(serviceUrl);
+		if(url is null) return false;
+		ClipboardEx.TrySetTextSafe(url);
 		return true;
 	}
 }

--- a/gitter.gitlab.prj/GitLabServiceContext.cs
+++ b/gitter.gitlab.prj/GitLabServiceContext.cs
@@ -22,6 +22,7 @@ namespace gitter.GitLab;
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
@@ -72,14 +73,17 @@ class GitLabServiceContext
 		=> _api.GetTestReportSummaryAsync(DefaultProjectId, pipelineId, cancellationToken);
 
 	public Task<IReadOnlyList<Issue>> GetIssuesAsync(
-		IssueState? state    = default,
-		IssueScope? scope    = default,
+		IssueState?   state     = default,
+		IssueScope?   scope     = default,
+		WorkItemType? issueType = default,
 		IReadOnlyCollection<string>? labels = default,
-		string?     milestone = default,
+		string?       milestone = default,
+		string?       search    = default,
 		CancellationToken cancellationToken = default)
-		=> _api.GetProjectIssuesAsync(DefaultProjectId, state, scope,
+		=> _api.GetProjectIssuesAsync(DefaultProjectId, state, scope, issueType,
 			labels:    labels,
 			milestone: milestone,
+			search:    search,
 			cancellationToken: cancellationToken);
 
 	public Task<IReadOnlyList<Label>> GetLabelsAsync(
@@ -90,20 +94,27 @@ class GitLabServiceContext
 	public Task<IReadOnlyList<Project>> GetProjectsAsync()
 		=> _api.GetProjectsAsync();
 
+	private string FormatUrl(string path)
+	{
+		var baseUrl = ServiceUri.ToString();
+		if(!baseUrl.EndsWith("/", StringComparison.Ordinal)) baseUrl += "/";
+		return baseUrl + path;
+	}
+
 	public string FormatProjectUrl()
-		=> ServiceUri + $@"{DefaultProjectId}";
+		=> FormatUrl($@"{DefaultProjectId}");
 
 	public string FormatCommitUrl(string sha)
-		=> ServiceUri + $@"{DefaultProjectId}/-/commit/{sha}";
+		=> FormatUrl($@"{DefaultProjectId}/-/commit/{sha}");
 
 	public string FormatPipelinesUrl()
-		=> ServiceUri + $@"{DefaultProjectId}/-/pipelines";
+		=> FormatUrl($@"{DefaultProjectId}/-/pipelines");
 
 	public string FormatIssuesUrl()
-		=> ServiceUri + $@"{DefaultProjectId}/-/issues";
+		=> FormatUrl($@"{DefaultProjectId}/-/issues");
 
-	public string FormatIssueUrl(int id)
-		=> ServiceUri + $@"{DefaultProjectId}/-/issues/{id}";
+	public string FormatIssueUrl(long iid)
+		=> FormatUrl($@"{DefaultProjectId}/-/issues/{iid.ToString(CultureInfo.InvariantCulture)}");
 
 	public Uri ServiceUri => _server.ServiceUri;
 

--- a/gitter.gitlab.prj/GitLabServiceProvider.cs
+++ b/gitter.gitlab.prj/GitLabServiceProvider.cs
@@ -131,43 +131,7 @@ sealed class GitLabServiceProvider : IRepositoryServiceProvider
 
 	private static bool Match(Uri serverUrl, string remoteFetchUrl,
 		[MaybeNullWhen(returnValue: false)] out string projectId)
-	{
-		if(string.IsNullOrWhiteSpace(remoteFetchUrl))
-		{
-			projectId = default;
-			return false;
-		}
-		const string GitPrefix = "git@";
-		if(remoteFetchUrl.StartsWith(GitPrefix))
-		{
-			int sep = remoteFetchUrl.IndexOf(':');
-			if(sep > 0 & sep < remoteFetchUrl.Length - 1)
-			{
-				var host = remoteFetchUrl.Substring(GitPrefix.Length, sep - GitPrefix.Length);
-				if(serverUrl.Host == host)
-				{
-					const string DotGit = ".git";
-					projectId = remoteFetchUrl.EndsWith(DotGit)
-						? remoteFetchUrl.Substring(sep + 1, remoteFetchUrl.Length - sep - DotGit.Length - 1)
-						: remoteFetchUrl.Substring(sep + 1);
-					return true;
-				}
-			}
-		}
-		else if(Uri.TryCreate(remoteFetchUrl, UriKind.Absolute, out var remoteUri))
-		{
-			if(remoteUri.Scheme is "http" or "https")
-			{
-				if(remoteUri.Host == serverUrl.Host)
-				{
-					projectId = remoteUri.PathAndQuery.Substring(1);
-					return true;
-				}
-			}
-		}
-		projectId = default;
-		return false;
-	}
+		=> RemoteUrlParser.TryGetProjectPath(serverUrl, remoteFetchUrl, out projectId);
 
 	private bool TryMatchServer(Git.Repository git,
 		[MaybeNullWhen(returnValue: false)] out ServerInfo server,

--- a/gitter.gitlab.prj/Gui/ColumnId.cs
+++ b/gitter.gitlab.prj/Gui/ColumnId.cs
@@ -36,4 +36,5 @@ public enum ColumnId
 	Hash,
 	Status,
 	Labels,
+	Type,
 }

--- a/gitter.gitlab.prj/Gui/IssuesView/Columns/IssueLabelsColumn.cs
+++ b/gitter.gitlab.prj/Gui/IssuesView/Columns/IssueLabelsColumn.cs
@@ -34,9 +34,9 @@ using Resources = gitter.GitLab.Properties.Resources;
 
 sealed class IssueLabelsColumn : CustomListBoxColumn
 {
-	private const int BaseChipHeight = 14;
-	private const int BaseChipPadX   = 4;
-	private const int BaseChipGap    = 4;
+	private const int BaseChipHeight = LabelChip.BaseHeight;
+	private const int BaseChipPadX   = LabelChip.BasePadX;
+	private const int BaseChipGap    = LabelChip.BaseGap;
 
 	public IssueLabelsColumn()
 		: base((int)ColumnId.Labels, Resources.StrLabels, visible: true)
@@ -103,54 +103,30 @@ sealed class IssueLabelsColumn : CustomListBoxColumn
 		var right  = bounds.Right - conv.ConvertX(2);
 
 		var registry = LabelRegistry.Current;
-		var oldHint  = g.TextRenderingHint;
-		var oldMode  = g.SmoothingMode;
-		g.SmoothingMode      = SmoothingMode.AntiAlias;
-		g.TextRenderingHint  = System.Drawing.Text.TextRenderingHint.ClearTypeGridFit;
-		try
+		using var scope = LabelChip.BeginDraw(g);
+
+		for(var i = 0; i < names.Length; i++)
 		{
-			for(var i = 0; i < names.Length; i++)
+			var name = names[i];
+			var (color, textColor) = LabelChip.GetColors(registry?.Find(name));
+
+			var chipWidth = LabelChip.MeasureWidth(g, font, name, padX);
+
+			if(x + chipWidth > right)
 			{
-				var name = names[i];
-				var label = registry?.Find(name);
-				var color = ParseColor(label?.Color) ?? Color.FromArgb(94, 110, 130);
-				var textColor = ParseColor(label?.TextColor) ?? AutoContrast(color);
-
-				var textWidth = (int)Math.Ceiling(g.MeasureString(name, font).Width);
-				var chipWidth = textWidth + 2 * padX;
-
-				if(x + chipWidth > right)
+				var remaining = names.Length - i;
+				var more = "+" + remaining.ToString(CultureInfo.InvariantCulture);
+				var moreChip = LabelChip.MeasureWidth(g, font, more, padX);
+				if(x + moreChip <= right + padX)
 				{
-					var remaining = names.Length - i;
-					var more = "+" + remaining.ToString(CultureInfo.InvariantCulture);
-					var moreW = (int)Math.Ceiling(g.MeasureString(more, font).Width);
-					var moreChip = moreW + 2 * padX;
-					if(x + moreChip <= right + padX)
-					{
-						DrawChip(g, font, x, top, moreChip, chipHeight, Color.Gray, Color.White, more, padX);
-					}
-					break;
+					LabelChip.Draw(g, font, x, top, moreChip, chipHeight, Color.Gray, Color.White, more, padX);
 				}
-
-				DrawChip(g, font, x, top, chipWidth, chipHeight, color, textColor, name, padX);
-				x += chipWidth + gap;
+				break;
 			}
-		}
-		finally
-		{
-			g.TextRenderingHint = oldHint;
-			g.SmoothingMode     = oldMode;
-		}
-	}
 
-	private static void DrawChip(Graphics g, Font font, int x, int y, int w, int h, Color fill, Color text, string label, int padX)
-	{
-		var radius = Math.Max(2, h / 2);
-		using var path = RoundedRect(new Rectangle(x, y, w, h), radius);
-		using var brush = new SolidBrush(fill);
-		g.FillPath(brush, path);
-		TextRenderer.DrawText(g, label, font, new Rectangle(x + padX, y, w - 2 * padX, h),
-			text, TextFormatFlags.VerticalCenter | TextFormatFlags.SingleLine | TextFormatFlags.NoPrefix);
+			LabelChip.Draw(g, font, x, top, chipWidth, chipHeight, color, textColor, name, padX);
+			x += chipWidth + gap;
+		}
 	}
 
 	private static int MeasureChipsTotalWidth(Graphics g, Font font, DpiConverter conv, string[] names)
@@ -160,48 +136,9 @@ sealed class IssueLabelsColumn : CustomListBoxColumn
 		var total = 0;
 		for(var i = 0; i < names.Length; i++)
 		{
-			var w = (int)Math.Ceiling(g.MeasureString(names[i], font).Width) + 2 * padX;
-			total += w;
+			total += LabelChip.MeasureWidth(g, font, names[i], padX);
 			if(i < names.Length - 1) total += gap;
 		}
 		return total + conv.ConvertX(4);
-	}
-
-	private static Color? ParseColor(string? hex)
-	{
-		if(string.IsNullOrEmpty(hex)) return null;
-		var s = hex!.TrimStart('#');
-		if(s.Length == 3)
-		{
-			// #abc -> #aabbcc
-			s = string.Concat(s[0], s[0], s[1], s[1], s[2], s[2]);
-		}
-		if(s.Length != 6) return null;
-		if(int.TryParse(s, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var rgb))
-		{
-			return Color.FromArgb(0xFF, (rgb >> 16) & 0xFF, (rgb >> 8) & 0xFF, rgb & 0xFF);
-		}
-		return null;
-	}
-
-	// YIQ luminance contrast
-	internal static Color AutoContrast(Color background)
-	{
-		var yiq = (background.R * 299 + background.G * 587 + background.B * 114) / 1000;
-		return yiq >= 128 ? Color.Black : Color.White;
-	}
-
-	private static GraphicsPath RoundedRect(Rectangle rect, int radius)
-	{
-		var path = new GraphicsPath();
-		var d = radius * 2;
-		if(d > rect.Width)  d = rect.Width;
-		if(d > rect.Height) d = rect.Height;
-		path.AddArc(rect.X,                rect.Y,                d, d, 180, 90);
-		path.AddArc(rect.Right - d - 1,    rect.Y,                d, d, 270, 90);
-		path.AddArc(rect.Right - d - 1,    rect.Bottom - d - 1,   d, d,   0, 90);
-		path.AddArc(rect.X,                rect.Bottom - d - 1,   d, d,  90, 90);
-		path.CloseFigure();
-		return path;
 	}
 }

--- a/gitter.gitlab.prj/Gui/IssuesView/Columns/IssueTypeColumn.cs
+++ b/gitter.gitlab.prj/Gui/IssuesView/Columns/IssueTypeColumn.cs
@@ -1,0 +1,86 @@
+#region Copyright Notice
+/*
+ * gitter - VCS repository management tool
+ * Copyright (C) 2026  Popovskiy Maxim Vladimirovitch <amgine.gitter@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#endregion
+
+namespace gitter.GitLab.Gui;
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Drawing;
+
+using gitter.Framework.Controls;
+
+using gitter.GitLab.Api;
+
+using Resources = gitter.GitLab.Properties.Resources;
+
+public sealed class IssueTypeColumn : CustomListBoxColumn
+{
+	public IssueTypeColumn()
+		: base((int)ColumnId.Type, Resources.StrType, visible: false)
+	{
+		Width = 80;
+	}
+
+	public override string IdentificationString => "Type";
+
+	protected override Comparison<CustomListBoxItem> SortComparison => IssueListItem.CompareByType;
+
+	internal static string GetDisplayName(WorkItemType type)
+		=> type switch
+		{
+			WorkItemType.Issue    => Resources.StrIssue,
+			WorkItemType.Incident => Resources.StrIncident,
+			WorkItemType.TestCase => Resources.StrTestCase,
+			WorkItemType.Task     => Resources.StrTask,
+			WorkItemType.Unknown  => string.Empty,
+			_ => type.ToString(),
+		};
+
+	private static bool TryGetContent(CustomListBoxItem item,
+		[MaybeNullWhen(returnValue: false)] out string value)
+	{
+		if(item is IssueListItem issue)
+		{
+			value = GetDisplayName(issue.DataContext.EffectiveType);
+			return value.Length != 0;
+		}
+		value = default;
+		return false;
+	}
+
+	protected override Size OnMeasureSubItem(SubItemMeasureEventArgs measureEventArgs)
+	{
+		if(TryGetContent(measureEventArgs.Item, out var value))
+		{
+			return measureEventArgs.MeasureText(value);
+		}
+		return base.OnMeasureSubItem(measureEventArgs);
+	}
+
+	protected override void OnPaintSubItem(SubItemPaintEventArgs paintEventArgs)
+	{
+		if(TryGetContent(paintEventArgs.Item, out var value))
+		{
+			paintEventArgs.PaintText(value);
+			return;
+		}
+		base.OnPaintSubItem(paintEventArgs);
+	}
+}

--- a/gitter.gitlab.prj/Gui/IssuesView/IssueListItem.cs
+++ b/gitter.gitlab.prj/Gui/IssuesView/IssueListItem.cs
@@ -61,6 +61,18 @@ sealed class IssueListItem : CustomListBoxItem<Issue>
 		return CompareById(i1, i2);
 	}
 
+	public static int CompareByType(IssueListItem item1, IssueListItem item2)
+		=> CompareString(
+			IssueTypeColumn.GetDisplayName(item1.DataContext.EffectiveType),
+			IssueTypeColumn.GetDisplayName(item2.DataContext.EffectiveType));
+
+	public static int CompareByType(CustomListBoxItem item1, CustomListBoxItem item2)
+	{
+		if(item1 is not IssueListItem i1) return 0;
+		if(item2 is not IssueListItem i2) return 0;
+		return CompareByType(i1, i2);
+	}
+
 	public static int CompareByTitle(IssueListItem item1, IssueListItem item2)
 		=> CompareString(item1.DataContext.Title, item2.DataContext.Title);
 

--- a/gitter.gitlab.prj/Gui/IssuesView/IssuesListBinding.cs
+++ b/gitter.gitlab.prj/Gui/IssuesView/IssuesListBinding.cs
@@ -35,10 +35,11 @@ using Resources = gitter.GitLab.Properties.Resources;
 
 sealed class IssuesListBinding : AsyncDataBinding<IReadOnlyList<Issue>>
 {
-	private IssueState? _issueState;
-	private IssueScope? _issueScope;
+	private IssueState?   _issueState;
+	private IssueScope?   _issueScope;
+	private WorkItemType? _issueType;
 	private IReadOnlyCollection<string>? _labels;
-	private string?     _milestone;
+	private string?       _milestone;
 
 	public IssuesListBinding(GitLabServiceContext serviceContext, CustomListBox issuesListBox,
 		IssueState? issueState = gitter.GitLab.Api.IssueState.Opened)
@@ -83,6 +84,19 @@ sealed class IssuesListBinding : AsyncDataBinding<IReadOnlyList<Issue>>
 		}
 	}
 
+	public WorkItemType? IssueType
+	{
+		get => _issueType;
+		set
+		{
+			if(_issueType != value)
+			{
+				_issueType = value;
+				ReloadData();
+			}
+		}
+	}
+
 	public IReadOnlyCollection<string>? Labels
 	{
 		get => _labels;
@@ -117,6 +131,7 @@ sealed class IssuesListBinding : AsyncDataBinding<IReadOnlyList<Issue>>
 		return ServiceContext.GetIssuesAsync(
 			state:     IssueState,
 			scope:     IssueScope,
+			issueType: IssueType,
 			labels:    Labels,
 			milestone: Milestone,
 			cancellationToken: cancellationToken);
@@ -154,9 +169,24 @@ sealed class IssuesListBinding : AsyncDataBinding<IReadOnlyList<Issue>>
 		}
 
 		IssuesListBox.ProgressMonitor.Report(OperationProgress.Completed);
-		IssuesListBox.Text = Resources.StrsFailedToFetchIssues;
+		IssuesListBox.Text   = FormatFailure(exception);
 		IssuesListBox.Items.Clear();
 		IssuesListBox.Cursor = Cursors.Default;
+	}
+
+	private static string FormatFailure(Exception exception)
+	{
+		var reason = exception switch
+		{
+			GitLabApiException          api  => api.Details  ?? api.Message,
+			GitLabUnauthorizedException auth => auth.Details ?? auth.Message,
+			null                             => null,
+			_                                => exception.Message,
+		};
+
+		return string.IsNullOrWhiteSpace(reason)
+			? Resources.StrsFailedToFetchIssues
+			: $"{Resources.StrsFailedToFetchIssues}{Environment.NewLine}{reason}";
 	}
 
 	protected override void Dispose(bool disposing)

--- a/gitter.gitlab.prj/Gui/IssuesView/IssuesListBox.cs
+++ b/gitter.gitlab.prj/Gui/IssuesView/IssuesListBox.cs
@@ -34,6 +34,7 @@ class IssuesListBox : CustomListBox
 		Columns.AddRange(
 			[
 				new IssueIdColumn(),
+				new IssueTypeColumn(),
 				new IssueAuthorColumn(),
 				new IssueCreatedAtColumn(),
 				new IssueUpdatedAtColumn(),

--- a/gitter.gitlab.prj/Gui/IssuesView/IssuesToolBar.cs
+++ b/gitter.gitlab.prj/Gui/IssuesView/IssuesToolBar.cs
@@ -43,8 +43,10 @@ internal sealed class IssuesToolbar : ToolStrip
 	private readonly ToolStripButton _btnScopeAll;
 	private readonly ToolStripButton _btnScopeCreated;
 	private readonly ToolStripButton _btnScopeAssigned;
+	private readonly ToolStripDropDownButton _btnType;
 	private readonly ToolStripDropDownButton _btnLabels;
 	private readonly ToolStripDropDownButton _btnMilestone;
+	private readonly LabelsFilterDropDown _labelsDropDown;
 	private bool _labelsChanged;
 
 	public IssuesToolbar(IssuesView view)
@@ -101,9 +103,22 @@ internal sealed class IssuesToolbar : ToolStrip
 		_btnScopeAssigned.Click += (_, _) => SetScope(Api.IssueScope.AssignedToMe);
 
 		Items.Add(new ToolStripSeparator());
-		Items.Add(_btnLabels = new ToolStripDropDownButton(Resources.StrLabels));
+		Items.Add(_btnType = new ToolStripDropDownButton(Resources.StrType));
+		_btnType.DropDownOpening += OnTypeDropDownOpening;
+		UpdateTypeCaption();
+
+		Items.Add(_btnLabels = new ToolStripDropDownButton(Resources.StrLabels)
+		{
+			DropDown = new Popup(_labelsDropDown = new LabelsFilterDropDown())
+			{
+				Resizable = false,
+			},
+			ToolTipText = Resources.StrLabels,
+		});
+		_labelsDropDown.SelectionChanged += (_, _) => _labelsChanged = true;
 		_btnLabels.DropDownOpening += OnLabelsDropDownOpening;
 		_btnLabels.DropDownClosed  += OnLabelsDropDownClosed;
+		UpdateLabelsCaption();
 
 		Items.Add(_btnMilestone = new ToolStripDropDownButton(Resources.StrMilestone));
 		_btnMilestone.DropDownOpening += OnMilestoneDropDownOpening;
@@ -127,42 +142,53 @@ internal sealed class IssuesToolbar : ToolStrip
 		_view.IssueScope          = scope;
 	}
 
-	private void OnLabelsDropDownOpening(object? sender, EventArgs e)
+	private void OnTypeDropDownOpening(object? sender, EventArgs e)
 	{
-		_btnLabels.DropDownItems.Clear();
-		_labelsChanged = false;
+		_btnType.DropDownItems.Clear();
 
-		var labels = _view.LabelRegistry?.All;
-		if(labels is null || labels.Count == 0)
+		AddTypeItem(Resources.StrAny, null);
+		_btnType.DropDownItems.Add(new ToolStripSeparator());
+		foreach(var type in Api.WorkItemTypes.Filterable)
 		{
-			_btnLabels.DropDownItems.Add(new ToolStripMenuItem("(no labels)") { Enabled = false });
-			return;
-		}
-
-		foreach(var label in labels)
-		{
-			var item = new ToolStripMenuItem(label.Name)
-			{
-				CheckOnClick = true,
-				Checked      = _view.SelectedLabels.Contains(label.Name),
-				Tag          = label.Name,
-			};
-			item.CheckedChanged += OnLabelChecked;
-			_btnLabels.DropDownItems.Add(item);
+			AddTypeItem(IssueTypeColumn.GetDisplayName(type), type);
 		}
 	}
 
-	private void OnLabelChecked(object? sender, EventArgs e) => _labelsChanged = true;
+	private void AddTypeItem(string display, Api.WorkItemType? value)
+	{
+		var item = new ToolStripMenuItem(display)
+		{
+			Checked = _view.IssueType == value,
+			Tag     = value,
+		};
+		item.Click += (_, _) =>
+		{
+			_view.IssueType = (Api.WorkItemType?)item.Tag;
+			UpdateTypeCaption();
+		};
+		_btnType.DropDownItems.Add(item);
+	}
+
+	private void UpdateTypeCaption()
+	{
+		_btnType.Text = _view.IssueType is { } type
+			? $"{Resources.StrType}: {IssueTypeColumn.GetDisplayName(type)}"
+			: Resources.StrType;
+	}
+
+	private void OnLabelsDropDownOpening(object? sender, EventArgs e)
+	{
+		_labelsChanged = false;
+		_labelsDropDown.SetSelectedLabels(_view.SelectedLabels);
+		_labelsDropDown.SetLabels(_view.LabelRegistry?.All);
+	}
 
 	private void OnLabelsDropDownClosed(object? sender, EventArgs e)
 	{
 		if(!_labelsChanged) return;
-		var selected = new List<string>();
-		foreach(ToolStripItem dd in _btnLabels.DropDownItems)
-		{
-			if(dd is ToolStripMenuItem { Checked: true, Tag: string name }) selected.Add(name);
-		}
-		_view.SetSelectedLabels(selected);
+
+		_labelsChanged = false;
+		_view.SetSelectedLabels(new List<string>(_labelsDropDown.SelectedLabels));
 		UpdateLabelsCaption();
 	}
 

--- a/gitter.gitlab.prj/Gui/IssuesView/IssuesView.cs
+++ b/gitter.gitlab.prj/Gui/IssuesView/IssuesView.cs
@@ -40,8 +40,9 @@ partial class IssuesView : GitLabViewBase, ISearchableView<IssuesSearchOptions>
 	private readonly IssuesToolbar _toolbar;
 	private ISearchToolBarController _searchToolbar;
 	private IssuesListBinding? _dataSource;
-	private IssueState? _issueState = Api.IssueState.Opened;
-	private IssueScope? _issueScope;
+	private IssueState?   _issueState = Api.IssueState.Opened;
+	private IssueScope?   _issueScope;
+	private WorkItemType? _issueType;
 	private HashSet<string> _selectedLabels = new(StringComparer.Ordinal);
 	private string? _selectedMilestone;
 	private LabelRegistry? _labelRegistry;
@@ -126,6 +127,17 @@ partial class IssuesView : GitLabViewBase, ISearchableView<IssuesSearchOptions>
 		}
 	}
 
+	public WorkItemType? IssueType
+	{
+		get => _issueType;
+		set
+		{
+			if(_issueType == value) return;
+			_issueType = value;
+			if(DataSource is not null) DataSource.IssueType = value;
+		}
+	}
+
 	public HashSet<string> SelectedLabels => _selectedLabels;
 
 	public void SetSelectedLabels(IEnumerable<string> labels)
@@ -173,6 +185,7 @@ partial class IssuesView : GitLabViewBase, ISearchableView<IssuesSearchOptions>
 		_ = _labelRegistry.RefreshAsync();
 		DataSource = new IssuesListBinding(serviceContext, _lstIssues, IssueState);
 		if(_issueScope        is not null) DataSource.IssueScope = _issueScope;
+		if(_issueType         is not null) DataSource.IssueType  = _issueType;
 		if(_selectedLabels.Count > 0)      DataSource.Labels     = _selectedLabels;
 		if(_selectedMilestone is not null) DataSource.Milestone  = _selectedMilestone;
 	}
@@ -200,6 +213,7 @@ partial class IssuesView : GitLabViewBase, ISearchableView<IssuesSearchOptions>
 		var filterNode = section.GetCreateSection("Filter");
 		filterNode.SetValue<string>("State",     _issueState?.ToString() ?? string.Empty);
 		filterNode.SetValue<string>("Scope",     _issueScope?.ToString() ?? string.Empty);
+		filterNode.SetValue<string>("Type",      _issueType?.ToString()  ?? string.Empty);
 		filterNode.SetValue<string>("Milestone", _selectedMilestone ?? string.Empty);
 		filterNode.SetValue<string>("Labels",    _selectedLabels.Count == 0
 			? string.Empty
@@ -221,6 +235,9 @@ partial class IssuesView : GitLabViewBase, ISearchableView<IssuesSearchOptions>
 
 		var rawScope = filterNode.GetValue<string>("Scope") ?? string.Empty;
 		_issueScope = Enum.TryParse<Api.IssueScope>(rawScope, out var sc) ? sc : null;
+
+		var rawType = filterNode.GetValue<string>("Type") ?? string.Empty;
+		_issueType = Enum.TryParse<WorkItemType>(rawType, out var wt) && wt != WorkItemType.Unknown ? wt : null;
 
 		var milestone = filterNode.GetValue<string>("Milestone") ?? string.Empty;
 		_selectedMilestone = milestone.Length == 0 ? null : milestone;

--- a/gitter.gitlab.prj/Gui/IssuesView/LabelChip.cs
+++ b/gitter.gitlab.prj/Gui/IssuesView/LabelChip.cs
@@ -1,0 +1,122 @@
+#region Copyright Notice
+/*
+ * gitter - VCS repository management tool
+ * Copyright (C) 2026  Popovskiy Maxim Vladimirovitch <amgine.gitter@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#endregion
+
+namespace gitter.GitLab.Gui;
+
+using System;
+using System.Drawing;
+using System.Drawing.Drawing2D;
+using System.Globalization;
+using System.Windows.Forms;
+
+using Label = gitter.GitLab.Api.Label;
+
+static class LabelChip
+{
+	public const int BaseHeight = 14;
+	public const int BasePadX   = 4;
+	public const int BaseGap    = 4;
+
+	public static readonly Color DefaultColor = Color.FromArgb(94, 110, 130);
+
+	public static (Color Fill, Color Text) GetColors(Label? label)
+	{
+		var fill = ParseColor(label?.Color) ?? DefaultColor;
+		var text = ParseColor(label?.TextColor) ?? AutoContrast(fill);
+		return (fill, text);
+	}
+
+	public static int MeasureWidth(Graphics graphics, Font font, string text, int padX)
+		=> (int)Math.Ceiling(graphics.MeasureString(text, font).Width) + 2 * padX;
+
+	public static void Draw(Graphics graphics, Font font, int x, int y, int w, int h,
+		Color fill, Color text, string label, int padX)
+	{
+		var radius = Math.Max(2, h / 2);
+		using var path  = RoundedRect(new Rectangle(x, y, w, h), radius);
+		using var brush = new SolidBrush(fill);
+		graphics.FillPath(brush, path);
+		TextRenderer.DrawText(graphics, label, font, new Rectangle(x + padX, y, w - 2 * padX, h),
+			text, TextFormatFlags.VerticalCenter | TextFormatFlags.SingleLine | TextFormatFlags.NoPrefix);
+	}
+
+	public static GraphicsModeScope BeginDraw(Graphics graphics) => new(graphics);
+
+	public readonly struct GraphicsModeScope : IDisposable
+	{
+		private readonly Graphics _graphics;
+		private readonly System.Drawing.Text.TextRenderingHint _hint;
+		private readonly SmoothingMode _mode;
+
+		internal GraphicsModeScope(Graphics graphics)
+		{
+			_graphics = graphics;
+			_hint     = graphics.TextRenderingHint;
+			_mode     = graphics.SmoothingMode;
+
+			graphics.SmoothingMode     = SmoothingMode.AntiAlias;
+			graphics.TextRenderingHint = System.Drawing.Text.TextRenderingHint.ClearTypeGridFit;
+		}
+
+		public void Dispose()
+		{
+			if(_graphics is null) return;
+			_graphics.TextRenderingHint = _hint;
+			_graphics.SmoothingMode     = _mode;
+		}
+	}
+
+	public static Color? ParseColor(string? hex)
+	{
+		if(string.IsNullOrEmpty(hex)) return null;
+
+		var s = hex!.TrimStart('#');
+		if(s.Length == 3)
+		{
+			s = string.Concat(s[0], s[0], s[1], s[1], s[2], s[2]);
+		}
+		if(s.Length != 6) return null;
+		if(int.TryParse(s, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var rgb))
+		{
+			return Color.FromArgb(0xFF, (rgb >> 16) & 0xFF, (rgb >> 8) & 0xFF, rgb & 0xFF);
+		}
+		return null;
+	}
+
+	public static Color AutoContrast(Color background)
+	{
+		var yiq = (background.R * 299 + background.G * 587 + background.B * 114) / 1000;
+		return yiq >= 128 ? Color.Black : Color.White;
+	}
+
+	private static GraphicsPath RoundedRect(Rectangle rect, int radius)
+	{
+		var path = new GraphicsPath();
+		var d = radius * 2;
+		if(d > rect.Width)  d = rect.Width;
+		if(d > rect.Height) d = rect.Height;
+		path.AddArc(rect.X,             rect.Y,              d, d, 180, 90);
+		path.AddArc(rect.Right - d - 1, rect.Y,              d, d, 270, 90);
+		path.AddArc(rect.Right - d - 1, rect.Bottom - d - 1, d, d,   0, 90);
+		path.AddArc(rect.X,             rect.Bottom - d - 1, d, d,  90, 90);
+		path.CloseFigure();
+		return path;
+	}
+}

--- a/gitter.gitlab.prj/Gui/IssuesView/LabelListItem.cs
+++ b/gitter.gitlab.prj/Gui/IssuesView/LabelListItem.cs
@@ -1,0 +1,87 @@
+#region Copyright Notice
+/*
+ * gitter - VCS repository management tool
+ * Copyright (C) 2026  Popovskiy Maxim Vladimirovitch <amgine.gitter@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#endregion
+
+namespace gitter.GitLab.Gui;
+
+using System.Drawing;
+
+using gitter.Framework.Controls;
+
+using gitter.GitLab.Api;
+
+sealed class LabelListItem : CustomListBoxItem<Label>
+{
+	public LabelListItem(Label label)
+		: base(label)
+	{
+		Verify.Argument.IsNotNull(label);
+
+		CheckedState = CheckedState.Unchecked;
+	}
+
+	protected override string GetToolTipText()
+		=> string.IsNullOrWhiteSpace(DataContext.Description)
+			? DataContext.Name
+			: DataContext.Name + "\n" + DataContext.Description;
+
+	protected override Size OnMeasureSubItem(SubItemMeasureEventArgs measureEventArgs)
+	{
+		if((ColumnId)measureEventArgs.SubItemId is not ColumnId.Name)
+		{
+			return base.OnMeasureSubItem(measureEventArgs);
+		}
+
+		var conv = measureEventArgs.DpiConverter;
+		var padX = conv.ConvertX(LabelChip.BasePadX);
+		var w = LabelChip.MeasureWidth(measureEventArgs.Gaphics,
+			measureEventArgs.Column.ContentFont, DataContext.Name, padX);
+
+		return new Size(w + conv.ConvertX(4), conv.ConvertY(LabelChip.BaseHeight + 4));
+	}
+
+	protected override void OnPaintSubItem(SubItemPaintEventArgs paintEventArgs)
+	{
+		if((ColumnId)paintEventArgs.SubItemId is not ColumnId.Name)
+		{
+			base.OnPaintSubItem(paintEventArgs);
+			return;
+		}
+
+		var g    = paintEventArgs.Graphics;
+		var conv = paintEventArgs.DpiConverter;
+		var font = paintEventArgs.Column.ContentFont;
+
+		var chipHeight = conv.ConvertY(LabelChip.BaseHeight);
+		var padX       = conv.ConvertX(LabelChip.BasePadX);
+
+		var bounds = paintEventArgs.Bounds;
+		var top    = bounds.Y + (bounds.Height - chipHeight) / 2;
+		var x      = bounds.X + conv.ConvertX(2);
+		var right  = bounds.Right - conv.ConvertX(2);
+
+		var (fill, text) = LabelChip.GetColors(DataContext);
+		var width = LabelChip.MeasureWidth(g, font, DataContext.Name, padX);
+		if(x + width > right) width = right - x;
+		if(width <= 0) return;
+
+		using var scope = LabelChip.BeginDraw(g);
+		LabelChip.Draw(g, font, x, top, width, chipHeight, fill, text, DataContext.Name, padX);
+	}
+}

--- a/gitter.gitlab.prj/Gui/IssuesView/LabelsFilterDropDown.cs
+++ b/gitter.gitlab.prj/Gui/IssuesView/LabelsFilterDropDown.cs
@@ -1,0 +1,245 @@
+#region Copyright Notice
+/*
+ * gitter - VCS repository management tool
+ * Copyright (C) 2026  Popovskiy Maxim Vladimirovitch <amgine.gitter@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#endregion
+
+namespace gitter.GitLab.Gui;
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Drawing;
+using System.Windows.Forms;
+
+using gitter.Framework;
+using gitter.Framework.Controls;
+using gitter.Framework.Layout;
+using gitter.Framework.Mvc;
+using gitter.Framework.Mvc.WinForms;
+
+using Label     = gitter.GitLab.Api.Label;
+using Resources = gitter.GitLab.Properties.Resources;
+
+[DesignerCategory("")]
+sealed class LabelsFilterDropDown : UserControl
+{
+	readonly struct DropDownControls
+	{
+		public readonly TextBox _txtFilter;
+		public readonly LabelsListBox _lstLabels;
+		public readonly LinkLabel _lnkClear;
+
+		public DropDownControls()
+		{
+			_txtFilter = new();
+			_lstLabels = new();
+			_lnkClear  = new()
+			{
+				LinkColor         = GitterApplication.Style.Colors.HyperlinkText,
+				ActiveLinkColor   = GitterApplication.Style.Colors.HyperlinkTextHotTrack,
+				DisabledLinkColor = GitterApplication.Style.Colors.GrayText,
+				TextAlign         = ContentAlignment.MiddleLeft,
+				Padding           = default,
+			};
+		}
+
+		public void Localize()
+		{
+			_lnkClear.Text = Resources.StrClearSelection;
+#if NETCOREAPP
+			_txtFilter.PlaceholderText = Resources.StrFilter;
+#endif
+		}
+
+		public void Layout(Control parent)
+		{
+			var filterDec = new TextBoxDecorator(_txtFilter);
+
+			_ = new ControlLayout(parent)
+			{
+				Content = new Grid(
+					padding: DpiBoundValue.Padding(new(4)),
+					rows:
+					[
+						LayoutConstants.TextInputRowHeight,
+						SizeSpec.Everything(),
+						LayoutConstants.LabelRowHeight,
+					],
+					content:
+					[
+						new GridContent(new ControlContent(filterDec,  marginOverride: LayoutConstants.TextBoxMargin), row: 0),
+						new GridContent(new ControlContent(_lstLabels, marginOverride: LayoutConstants.NoMargin),      row: 1),
+						new GridContent(new ControlContent(_lnkClear,  marginOverride: LayoutConstants.NoMargin),      row: 2),
+					]),
+			};
+
+			var tabIndex = 0;
+			filterDec.TabIndex = tabIndex++;
+			_lstLabels.TabIndex = tabIndex++;
+			_lnkClear.TabIndex = tabIndex++;
+
+			filterDec.Parent  = parent;
+			_lstLabels.Parent = parent;
+			_lnkClear.Parent  = parent;
+		}
+	}
+
+	private readonly DropDownControls _controls;
+	private readonly LabelsFilterModel _model = new();
+	private bool _suppressCheckEvents;
+
+	public event EventHandler? SelectionChanged;
+
+	public IUserInputSource<string?> Filter { get; }
+
+	public LabelsFilterDropDown()
+	{
+		Name = nameof(LabelsFilterDropDown);
+
+		SuspendLayout();
+		AutoScaleDimensions = Dpi.Default;
+		AutoScaleMode       = AutoScaleMode.Dpi;
+		BorderStyle         = BorderStyle.FixedSingle;
+		MinimumSize         = new(240, 260);
+		MaximumSize         = new(240, 420);
+		Size                = new(240, 320);
+		_controls = new();
+		_controls.Localize();
+		_controls.Layout(this);
+		ResumeLayout(performLayout: false);
+		PerformLayout();
+
+		if(LicenseManager.UsageMode == LicenseUsageMode.Runtime)
+		{
+			Font      = GitterApplication.FontManager.UIFont;
+			BackColor = GitterApplication.Style.Colors.Window;
+			ForeColor = GitterApplication.Style.Colors.WindowText;
+		}
+		else
+		{
+			Font      = SystemFonts.MessageBoxFont;
+			BackColor = SystemColors.Window;
+		}
+
+		Filter = new TextBoxInputSource(_controls._txtFilter);
+
+		_controls._txtFilter.TextChanged   += OnFilterTextChanged;
+		_controls._lstLabels.ItemCheckedChanged += OnItemCheckedChanged;
+		_controls._lnkClear.LinkClicked    += OnClearLinkClicked;
+
+		VisibleChanged += OnVisibleChanged;
+	}
+
+	protected override bool ScaleChildren => false;
+
+	public void SetLabels(IReadOnlyList<Label>? labels)
+	{
+		_model.Labels = labels!;
+		Rebuild();
+	}
+
+	public IReadOnlyCollection<string> SelectedLabels => _model.Selected;
+
+	public void SetSelectedLabels(IEnumerable<string>? labels)
+	{
+		_model.SetSelected(labels);
+		ApplyCheckStates();
+		UpdateClearLinkState();
+	}
+
+	private void Rebuild()
+	{
+		_suppressCheckEvents = true;
+		_controls._lstLabels.BeginUpdate();
+		try
+		{
+			_controls._lstLabels.Items.Clear();
+			foreach(var label in _model.GetVisibleLabels(_controls._txtFilter.Text))
+			{
+				_controls._lstLabels.Items.Add(new LabelListItem(label)
+				{
+					IsChecked = _model.IsSelected(label.Name),
+				});
+			}
+		}
+		finally
+		{
+			_controls._lstLabels.EndUpdate();
+			_suppressCheckEvents = false;
+		}
+		UpdateClearLinkState();
+	}
+
+	private void ApplyCheckStates()
+	{
+		_suppressCheckEvents = true;
+		try
+		{
+			foreach(var item in _controls._lstLabels.Items)
+			{
+				if(item is LabelListItem label)
+				{
+					label.IsChecked = _model.IsSelected(label.DataContext.Name);
+				}
+			}
+		}
+		finally
+		{
+			_suppressCheckEvents = false;
+		}
+	}
+
+	private void OnFilterTextChanged(object? sender, EventArgs e) => Rebuild();
+
+	private void OnItemCheckedChanged(object? sender, ItemEventArgs e)
+	{
+		if(_suppressCheckEvents) return;
+		if(e.Item is not LabelListItem label) return;
+
+		if(!_model.Select(label.DataContext.Name, e.Item.IsChecked)) return;
+
+		UpdateClearLinkState();
+		SelectionChanged?.Invoke(this, EventArgs.Empty);
+	}
+
+	private void OnClearLinkClicked(object? sender, LinkLabelLinkClickedEventArgs e)
+	{
+		if(!_model.Clear()) return;
+
+		ApplyCheckStates();
+		UpdateClearLinkState();
+		SelectionChanged?.Invoke(this, EventArgs.Empty);
+	}
+
+	private void UpdateClearLinkState()
+	{
+		var count = _model.SelectedCount;
+		_controls._lnkClear.Text = count == 0
+			? Resources.StrClearSelection
+			: $"{Resources.StrClearSelection} ({count})";
+		_controls._lnkClear.Links[0].Enabled = count != 0;
+	}
+
+	private void OnVisibleChanged(object? sender, EventArgs e)
+	{
+		if(!Visible) return;
+
+		Filter.Value = string.Empty;
+		if(IsHandleCreated) BeginInvoke(_controls._txtFilter.Focus);
+	}
+}

--- a/gitter.gitlab.prj/Gui/IssuesView/LabelsFilterModel.cs
+++ b/gitter.gitlab.prj/Gui/IssuesView/LabelsFilterModel.cs
@@ -1,0 +1,103 @@
+#region Copyright Notice
+/*
+ * gitter - VCS repository management tool
+ * Copyright (C) 2026  Popovskiy Maxim Vladimirovitch <amgine.gitter@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#endregion
+
+namespace gitter.GitLab.Gui;
+
+using System;
+using System.Collections.Generic;
+
+using gitter.Framework;
+
+using Label = gitter.GitLab.Api.Label;
+
+sealed class LabelsFilterModel
+{
+	private readonly HashSet<string> _selected = new(StringComparer.Ordinal);
+	private IReadOnlyList<Label> _labels = Preallocated<Label>.EmptyArray;
+
+	public IReadOnlyList<Label> Labels
+	{
+		get => _labels;
+		set => _labels = value ?? Preallocated<Label>.EmptyArray;
+	}
+
+	public IReadOnlyCollection<string> Selected => _selected;
+
+	public int SelectedCount => _selected.Count;
+
+	public bool IsSelected(string name) => _selected.Contains(name);
+
+	public bool Select(string name, bool selected)
+	{
+		if(string.IsNullOrEmpty(name)) return false;
+
+		return selected ? _selected.Add(name) : _selected.Remove(name);
+	}
+
+	public void SetSelected(IEnumerable<string>? names)
+	{
+		_selected.Clear();
+		if(names is null) return;
+
+		foreach(var name in names)
+		{
+			if(!string.IsNullOrEmpty(name)) _selected.Add(name);
+		}
+	}
+
+	public bool Clear()
+	{
+		if(_selected.Count == 0) return false;
+
+		_selected.Clear();
+		return true;
+	}
+
+	public List<Label> GetVisibleLabels(string? filter)
+	{
+		var result = new List<Label>(_labels.Count);
+		foreach(var label in _labels)
+		{
+			if(Matches(label, filter)) result.Add(label);
+		}
+		return result;
+	}
+
+	public static bool Matches(Label? label, string? filter)
+	{
+		if(label is null) return false;
+		if(string.IsNullOrWhiteSpace(filter)) return true;
+
+		var needle = filter!.Trim();
+
+		return Contains(label.Name, needle) || Contains(label.Description, needle);
+	}
+
+	private static bool Contains(string? haystack, string needle)
+	{
+		if(haystack is not { Length: not 0 }) return false;
+
+#if NET6_0_OR_GREATER
+		return haystack.Contains(needle, StringComparison.OrdinalIgnoreCase);
+#else
+		return haystack.IndexOf(needle, StringComparison.OrdinalIgnoreCase) >= 0;
+#endif
+	}
+}

--- a/gitter.gitlab.prj/Gui/IssuesView/LabelsListBox.cs
+++ b/gitter.gitlab.prj/Gui/IssuesView/LabelsListBox.cs
@@ -1,0 +1,49 @@
+#region Copyright Notice
+/*
+ * gitter - VCS repository management tool
+ * Copyright (C) 2026  Popovskiy Maxim Vladimirovitch <amgine.gitter@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#endregion
+
+namespace gitter.GitLab.Gui;
+
+using gitter.Framework.Controls;
+
+using Resources = gitter.GitLab.Properties.Resources;
+
+sealed class LabelsListBox : CustomListBox
+{
+	public LabelsListBox()
+	{
+		Columns.Add(new LabelNameColumn());
+
+		HeaderStyle         = HeaderStyle.Hidden;
+		ShowCheckBoxes      = true;
+		DisableContextMenus = true;
+		Text                = Resources.StrsNoLabelsToDisplay;
+	}
+
+	private sealed class LabelNameColumn : CustomListBoxColumn
+	{
+		public LabelNameColumn()
+			: base((int)ColumnId.Name, Resources.StrLabel, visible: true)
+		{
+			SizeMode = ColumnSizeMode.Fill;
+		}
+
+		public override string IdentificationString => "LabelName";
+	}
+}

--- a/gitter.gitlab.prj/Properties/Resources.Designer.cs
+++ b/gitter.gitlab.prj/Properties/Resources.Designer.cs
@@ -322,6 +322,33 @@ namespace gitter.GitLab.Properties {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to Filter.
+        /// </summary>
+        internal static string StrFilter {
+            get {
+                return ResourceManager.GetString("StrFilter", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Clear selection.
+        /// </summary>
+        internal static string StrClearSelection {
+            get {
+                return ResourceManager.GetString("StrClearSelection", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to No labels to display.
+        /// </summary>
+        internal static string StrsNoLabelsToDisplay {
+            get {
+                return ResourceManager.GetString("StrsNoLabelsToDisplay", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Branches.
         /// </summary>
         internal static string StrBranches {
@@ -518,6 +545,51 @@ namespace gitter.GitLab.Properties {
                 return ResourceManager.GetString("StrMilestone", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Type.
+        /// </summary>
+        internal static string StrType {
+            get {
+                return ResourceManager.GetString("StrType", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Issue.
+        /// </summary>
+        internal static string StrIssue {
+            get {
+                return ResourceManager.GetString("StrIssue", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Incident.
+        /// </summary>
+        internal static string StrIncident {
+            get {
+                return ResourceManager.GetString("StrIncident", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Test case.
+        /// </summary>
+        internal static string StrTestCase {
+            get {
+                return ResourceManager.GetString("StrTestCase", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Task.
+        /// </summary>
+        internal static string StrTask {
+            get {
+                return ResourceManager.GetString("StrTask", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to Name.
@@ -663,6 +735,15 @@ namespace gitter.GitLab.Properties {
             }
         }
         
+        /// <summary>
+        ///   Looks up a localized string similar to Copy access tokens page link.
+        /// </summary>
+        internal static string StrsCopyAccessTokensUrl {
+            get {
+                return ResourceManager.GetString("StrsCopyAccessTokensUrl", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Manage access tokens.
         /// </summary>

--- a/gitter.gitlab.prj/Properties/Resources.resx
+++ b/gitter.gitlab.prj/Properties/Resources.resx
@@ -204,6 +204,15 @@
   <data name="StrLabels" xml:space="preserve">
     <value>Labels</value>
   </data>
+  <data name="StrFilter" xml:space="preserve">
+    <value>Filter</value>
+  </data>
+  <data name="StrClearSelection" xml:space="preserve">
+    <value>Clear selection</value>
+  </data>
+  <data name="StrsNoLabelsToDisplay" xml:space="preserve">
+    <value>No labels to display</value>
+  </data>
   <data name="StrBranches" xml:space="preserve">
     <value>Branches</value>
   </data>
@@ -318,6 +327,9 @@
   <data name="StrSkippedTests" xml:space="preserve">
     <value>Skipped Tests</value>
   </data>
+  <data name="StrsCopyAccessTokensUrl" xml:space="preserve">
+    <value>Copy access tokens page link</value>
+  </data>
   <data name="StrsManageAccessTokens" xml:space="preserve">
     <value>Manage access tokens</value>
   </data>
@@ -347,6 +359,21 @@
   </data>
   <data name="StrTitle" xml:space="preserve">
     <value>Title</value>
+  </data>
+  <data name="StrType" xml:space="preserve">
+    <value>Type</value>
+  </data>
+  <data name="StrIssue" xml:space="preserve">
+    <value>Issue</value>
+  </data>
+  <data name="StrIncident" xml:space="preserve">
+    <value>Incident</value>
+  </data>
+  <data name="StrTestCase" xml:space="preserve">
+    <value>Test case</value>
+  </data>
+  <data name="StrTask" xml:space="preserve">
+    <value>Task</value>
   </data>
   <data name="StrUpdatedAt" xml:space="preserve">
     <value>Updated</value>

--- a/gitter.gitlab.prj/RemoteUrlParser.cs
+++ b/gitter.gitlab.prj/RemoteUrlParser.cs
@@ -1,0 +1,119 @@
+#region Copyright Notice
+/*
+ * gitter - VCS repository management tool
+ * Copyright (C) 2026  Popovskiy Maxim Vladimirovitch <amgine.gitter@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#endregion
+
+namespace gitter.GitLab;
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+static class RemoteUrlParser
+{
+	private const string DotGit = @".git";
+
+	public static bool TryGetProjectPath(Uri? serviceUri, string? remoteFetchUrl,
+		[MaybeNullWhen(returnValue: false)] out string projectPath)
+	{
+		projectPath = default;
+
+		if(serviceUri is null) return false;
+		if(string.IsNullOrWhiteSpace(remoteFetchUrl)) return false;
+
+		var remote = remoteFetchUrl!.Trim();
+
+		if(TryParseScpLike(remote, out var scpHost, out var scpPath))
+		{
+			if(!HostMatches(serviceUri, scpHost, port: -1)) return false;
+			return TryNormalize(scpPath, out projectPath);
+		}
+
+		if(!Uri.TryCreate(remote, UriKind.Absolute, out var uri)) return false;
+
+		var isWeb = uri.Scheme is @"http" or @"https";
+		if(!isWeb && uri.Scheme is not (@"ssh" or @"git")) return false;
+		if(!HostMatches(serviceUri, uri.Host, isWeb ? uri.Port : -1)) return false;
+
+		var path = uri.AbsolutePath;
+		if(isWeb) path = StripBasePath(serviceUri, path);
+
+		return TryNormalize(path, out projectPath);
+	}
+
+	private static bool TryParseScpLike(string url,
+		[MaybeNullWhen(returnValue: false)] out string host,
+		[MaybeNullWhen(returnValue: false)] out string path)
+	{
+		host = default;
+		path = default;
+
+		if(url.IndexOf(@"://", StringComparison.Ordinal) >= 0) return false;
+
+		var colon = url.IndexOf(':');
+		if(colon <= 0) return false;
+
+		var slash = url.IndexOfAny(['/', '\\']);
+		if(slash >= 0 && slash < colon) return false;
+
+		var authority = url.Substring(0, colon);
+		var at = authority.LastIndexOf('@');
+		host = at >= 0 ? authority.Substring(at + 1) : authority;
+		if(host.Length == 0) return false;
+
+		path = url.Substring(colon + 1);
+		return path.Length != 0;
+	}
+
+	private static bool HostMatches(Uri serviceUri, string host, int port)
+	{
+		if(!string.Equals(serviceUri.Host, host, StringComparison.OrdinalIgnoreCase)) return false;
+
+		return port < 0 || port == serviceUri.Port;
+	}
+
+	private static string StripBasePath(Uri serviceUri, string path)
+	{
+		var basePath = serviceUri.AbsolutePath.Trim('/');
+		if(basePath.Length == 0) return path;
+
+		var trimmed = path.TrimStart('/');
+		if(trimmed.Length > basePath.Length
+			&& trimmed.StartsWith(basePath, StringComparison.OrdinalIgnoreCase)
+			&& trimmed[basePath.Length] == '/')
+		{
+			return trimmed.Substring(basePath.Length + 1);
+		}
+		return path;
+	}
+
+	private static bool TryNormalize(string path,
+		[MaybeNullWhen(returnValue: false)] out string projectPath)
+	{
+		projectPath = default;
+
+		var value = Uri.UnescapeDataString(path).Trim().Trim('/');
+		if(value.EndsWith(DotGit, StringComparison.OrdinalIgnoreCase))
+		{
+			value = value.Substring(0, value.Length - DotGit.Length).TrimEnd('/');
+		}
+		if(value.Length == 0) return false;
+
+		projectPath = value;
+		return true;
+	}
+}

--- a/shared/HttpPolyfills.cs
+++ b/shared/HttpPolyfills.cs
@@ -28,6 +28,12 @@ static class HttpContentExtensions
 			_ = cancellationToken;
 			return content.ReadAsStreamAsync();
 		}
+
+		public System.Threading.Tasks.Task<string> ReadAsStringAsync(System.Threading.CancellationToken cancellationToken)
+		{
+			_ = cancellationToken;
+			return content.ReadAsStringAsync();
+		}
 	}
 }
 #endif

--- a/tests/gitter.tests.prj/GitLab/ApiEndpointIssuesTests.cs
+++ b/tests/gitter.tests.prj/GitLab/ApiEndpointIssuesTests.cs
@@ -1,0 +1,330 @@
+#region Copyright Notice
+/*
+ * gitter - VCS repository management tool
+ * Copyright (C) 2013  Popovskiy Maxim Vladimirovitch <amgine.gitter@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#endregion
+
+namespace gitter.GitLab.Api;
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+using NUnit.Framework;
+
+[TestFixture]
+class ApiEndpointIssuesTests
+{
+	private sealed class RecordingHandler : HttpMessageHandler
+	{
+		private readonly Queue<HttpResponseMessage> _responses;
+		public List<string> RequestedUrls { get; } = new();
+		public RecordingHandler(params HttpResponseMessage[] responses)
+		{
+			_responses = new Queue<HttpResponseMessage>(responses);
+		}
+		protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+		{
+			RequestedUrls.Add(request.RequestUri!.AbsoluteUri);
+			var response = _responses.Count > 0 ? _responses.Dequeue() : new HttpResponseMessage(HttpStatusCode.NotFound);
+			response.RequestMessage = request;
+			return Task.FromResult(response);
+		}
+	}
+
+	private static ApiEndpoint MakeEndpoint(RecordingHandler handler)
+	{
+		var invoker = new HttpMessageInvoker(handler);
+		var server  = new ServerInfo("test", new Uri("https://gitlab.example.com"), "token");
+		return new ApiEndpoint(invoker, server);
+	}
+
+	private static HttpResponseMessage Json(string body, HttpStatusCode status = HttpStatusCode.OK)
+		=> new(status) { Content = new StringContent(body, System.Text.Encoding.UTF8, "application/json") };
+
+	private static async Task<string> RequestUrlAsync(Func<ApiEndpoint, Task> call)
+	{
+		var handler  = new RecordingHandler(Json("[]"));
+		var endpoint = MakeEndpoint(handler);
+		await call(endpoint);
+		Assert.That(handler.RequestedUrls, Has.Count.EqualTo(1));
+		return handler.RequestedUrls[0];
+	}
+
+	#region project path
+
+	[Test]
+	public async Task ProjectPath_IsUrlEncoded()
+	{
+		var url = await RequestUrlAsync(e => e.GetProjectIssuesAsync(NameOrNumericId.FromName("group/project")));
+		Assert.That(url, Does.Contain("/api/v4/projects/group%2Fproject/issues"));
+	}
+
+	[Test]
+	public async Task NestedProjectPath_EncodesSlashesButNotDots()
+	{
+		var url = await RequestUrlAsync(e => e.GetProjectIssuesAsync(
+			NameOrNumericId.FromName("promcontrol/viscont/nugets/viscont.core.framework.sparkpulse")));
+
+		Assert.That(url, Does.Contain(
+			"/api/v4/projects/promcontrol%2Fviscont%2Fnugets%2Fviscont.core.framework.sparkpulse/issues"));
+	}
+
+	[Test]
+	public async Task NumericProjectId_IsUsedVerbatim()
+	{
+		var url = await RequestUrlAsync(e => e.GetProjectIssuesAsync(NameOrNumericId.FromId(42)));
+		Assert.That(url, Does.Contain("/api/v4/projects/42/issues"));
+	}
+
+	#endregion
+
+	#region work item type filter
+
+	[TestCase(WorkItemType.Issue,    @"issue_type=issue")]
+	[TestCase(WorkItemType.Incident, @"issue_type=incident")]
+	[TestCase(WorkItemType.TestCase, @"issue_type=test_case")]
+	[TestCase(WorkItemType.Task,     @"issue_type=task")]
+	public async Task IssueType_IsSentAsSnakeCase(WorkItemType type, string expected)
+	{
+		var url = await RequestUrlAsync(e => e.GetProjectIssuesAsync(NameOrNumericId.FromId(1), issueType: type));
+		Assert.That(url, Does.Contain(expected));
+	}
+
+	[Test]
+	public async Task IssueType_OmittedWhenNotRequested()
+	{
+		var url = await RequestUrlAsync(e => e.GetProjectIssuesAsync(NameOrNumericId.FromId(1)));
+		Assert.That(url, Does.Not.Contain("issue_type"));
+	}
+
+	[Test]
+	public void IssueType_Unknown_IsRejected()
+	{
+		var handler  = new RecordingHandler(Json("[]"));
+		var endpoint = MakeEndpoint(handler);
+
+		Assert.ThrowsAsync<ArgumentException>(
+			() => endpoint.GetProjectIssuesAsync(NameOrNumericId.FromId(1), issueType: WorkItemType.Unknown));
+	}
+
+	#endregion
+
+	#region filters
+
+	[Test]
+	public async Task State_And_Scope_AreSent()
+	{
+		var url = await RequestUrlAsync(e => e.GetProjectIssuesAsync(NameOrNumericId.FromId(1),
+			state: IssueState.Closed, scope: IssueScope.AssignedToMe));
+
+		Assert.That(url, Does.Contain("state=closed"));
+		Assert.That(url, Does.Contain("scope=assigned_to_me"));
+	}
+
+	[Test]
+	public async Task OrderBy_IsSentAsSnakeCase()
+	{
+		var url = await RequestUrlAsync(e => e.GetProjectIssuesAsync(NameOrNumericId.FromId(1),
+			orderBy: IssueOrderBy.UpdatedAt, sort: SortOrder.Ascending));
+
+		Assert.That(url, Does.Contain("order_by=updated_at"));
+		Assert.That(url, Does.Contain("sort=asc"));
+	}
+
+	[Test]
+	public async Task Labels_AreCommaSeparatedAndIndividuallyEncoded()
+	{
+		var url = await RequestUrlAsync(e => e.GetProjectIssuesAsync(NameOrNumericId.FromId(1),
+			labels: ["needs review", "ui"]));
+
+		Assert.That(url, Does.Contain("labels=needs%20review,ui"));
+	}
+
+	[Test]
+	public async Task Labels_NoneKeyword_IsNotEncoded()
+	{
+		var url = await RequestUrlAsync(e => e.GetProjectIssuesAsync(NameOrNumericId.FromId(1),
+			labels: [ApiEndpoint.NoneFilter]));
+
+		Assert.That(url, Does.Contain("labels=None"));
+	}
+
+	[Test]
+	public async Task Milestone_AnyKeyword_IsNotEncoded()
+	{
+		var url = await RequestUrlAsync(e => e.GetProjectIssuesAsync(NameOrNumericId.FromId(1),
+			milestone: ApiEndpoint.AnyFilter));
+
+		Assert.That(url, Does.Contain("milestone=Any"));
+	}
+
+	[Test]
+	public async Task Milestone_IsEncoded()
+	{
+		var url = await RequestUrlAsync(e => e.GetProjectIssuesAsync(NameOrNumericId.FromId(1),
+			milestone: "v1.0 rc"));
+
+		Assert.That(url, Does.Contain("milestone=v1.0%20rc"));
+	}
+
+	[Test]
+	public async Task Search_IsEncoded()
+	{
+		var url = await RequestUrlAsync(e => e.GetProjectIssuesAsync(NameOrNumericId.FromId(1),
+			search: "crash on start"));
+
+		Assert.That(url, Does.Contain("search=crash%20on%20start"));
+	}
+
+	[Test]
+	public async Task Iids_AreRepeated()
+	{
+		var url = await RequestUrlAsync(e => e.GetProjectIssuesAsync(NameOrNumericId.FromId(1),
+			iids: [3L, 4L]));
+
+		Assert.That(url, Does.Contain("iids[]=3").IgnoreCase.Or.Contain("iids%5B%5D=3"));
+		Assert.That(url, Does.Contain("4"));
+	}
+
+	[Test]
+	public async Task Dates_AreEncodedSoPlusSurvives()
+	{
+		var stamp = new DateTimeOffset(2026, 3, 1, 12, 0, 0, TimeSpan.FromHours(3));
+		var url = await RequestUrlAsync(e => e.GetProjectIssuesAsync(NameOrNumericId.FromId(1),
+			updatedAfter: stamp));
+
+		Assert.That(url, Does.Not.Contain("+"));
+		Assert.That(url, Does.Contain("updated_after=2026-03-01T12%3A00%3A00%2B0300"));
+	}
+
+	[Test]
+	public async Task Confidential_IsSentAsBoolean()
+	{
+		var url = await RequestUrlAsync(e => e.GetProjectIssuesAsync(NameOrNumericId.FromId(1),
+			confidential: false));
+
+		Assert.That(url, Does.Contain("confidential=false"));
+	}
+
+	#endregion
+
+	#region pagination
+
+	[Test]
+	public async Task PageSize_IsRequestedExplicitly()
+	{
+		var url = await RequestUrlAsync(e => e.GetProjectIssuesAsync(NameOrNumericId.FromId(1)));
+		Assert.That(url, Does.Contain("per_page=100"));
+	}
+
+	[Test]
+	public async Task PageSize_IsAppendedToAnExistingQuery()
+	{
+		var url = await RequestUrlAsync(e => e.GetProjectIssuesAsync(NameOrNumericId.FromId(1),
+			state: IssueState.Opened));
+
+		Assert.That(url, Does.Contain("state=opened"));
+		Assert.That(url, Does.Contain("per_page=100"));
+		Assert.That(url.Split('?'), Has.Length.EqualTo(2));
+	}
+
+	[Test]
+	public async Task LinkHeader_WithCommasInsideUrl_IsParsedCorrectly()
+	{
+		var page1 = Json("""[{"iid":1}]""");
+		page1.Headers.Add("Link",
+			"""<https://gitlab.example.com/api/v4/projects/1/issues?labels=bug,ui&page=2>; rel="next", <https://gitlab.example.com/api/v4/projects/1/issues?labels=bug,ui&page=9>; rel="last" """);
+		var page2 = Json("""[{"iid":2}]""");
+
+		var handler  = new RecordingHandler(page1, page2);
+		var endpoint = MakeEndpoint(handler);
+
+		var issues = await endpoint.GetProjectIssuesAsync(NameOrNumericId.FromId(1), labels: ["bug", "ui"]);
+
+		Assert.That(handler.RequestedUrls, Has.Count.EqualTo(2));
+		Assert.That(handler.RequestedUrls[1], Does.Contain("page=2"));
+		Assert.That(issues, Has.Count.EqualTo(2));
+	}
+
+	[Test]
+	public async Task LinkHeader_WithoutNextRelation_StopsAfterOnePage()
+	{
+		var page1 = Json("""[{"iid":1}]""");
+		page1.Headers.Add("Link",
+			"""<https://gitlab.example.com/api/v4/projects/1/issues?page=1>; rel="prev" """);
+
+		var handler  = new RecordingHandler(page1);
+		var endpoint = MakeEndpoint(handler);
+
+		var issues = await endpoint.GetProjectIssuesAsync(NameOrNumericId.FromId(1));
+
+		Assert.That(handler.RequestedUrls, Has.Count.EqualTo(1));
+		Assert.That(issues, Has.Count.EqualTo(1));
+	}
+
+	#endregion
+
+	#region error reporting
+
+	[Test]
+	public void NotFound_ThrowsWithServerMessageAndUrl()
+	{
+		var handler  = new RecordingHandler(Json("""{"message":"404 Project Not Found"}""", HttpStatusCode.NotFound));
+		var endpoint = MakeEndpoint(handler);
+
+		var ex = Assert.ThrowsAsync<GitLabApiException>(
+			() => endpoint.GetProjectIssuesAsync(NameOrNumericId.FromName("group/project.git")));
+
+		Assert.That(ex!.StatusCode, Is.EqualTo(HttpStatusCode.NotFound));
+		Assert.That(ex.Details,     Is.EqualTo("404 Project Not Found"));
+		Assert.That(ex.Message,     Does.Contain("404 Project Not Found"));
+		Assert.That(ex.Message,     Does.Contain("group%2Fproject.git"));
+	}
+
+	[Test]
+	public void Unauthorized_StillThrowsUnauthorizedAccessException()
+	{
+		var handler  = new RecordingHandler(Json("""{"message":"401 Unauthorized"}""", HttpStatusCode.Unauthorized));
+		var endpoint = MakeEndpoint(handler);
+
+		var ex = Assert.ThrowsAsync<GitLabUnauthorizedException>(
+			() => endpoint.GetProjectIssuesAsync(NameOrNumericId.FromId(1)));
+
+		Assert.That(ex, Is.InstanceOf<UnauthorizedAccessException>());
+		Assert.That(ex!.Details, Is.EqualTo("401 Unauthorized"));
+	}
+
+	[Test]
+	public void NonJsonErrorBody_IsStillReported()
+	{
+		var handler = new RecordingHandler(
+			new HttpResponseMessage(HttpStatusCode.BadGateway) { Content = new StringContent("<html>bad gateway</html>") });
+		var endpoint = MakeEndpoint(handler);
+
+		var ex = Assert.ThrowsAsync<GitLabApiException>(
+			() => endpoint.GetProjectIssuesAsync(NameOrNumericId.FromId(1)));
+
+		Assert.That(ex!.StatusCode, Is.EqualTo(HttpStatusCode.BadGateway));
+		Assert.That(ex.Details,     Does.Contain("bad gateway"));
+	}
+
+	#endregion
+}

--- a/tests/gitter.tests.prj/GitLab/IssueParsingTests.cs
+++ b/tests/gitter.tests.prj/GitLab/IssueParsingTests.cs
@@ -1,0 +1,178 @@
+#region Copyright Notice
+/*
+ * gitter - VCS repository management tool
+ * Copyright (C) 2013  Popovskiy Maxim Vladimirovitch <amgine.gitter@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#endregion
+
+namespace gitter.GitLab.Api;
+
+using System.Text.Json;
+
+using NUnit.Framework;
+
+[TestFixture]
+class IssueParsingTests
+{
+	private const string WorkItemJson = """
+		{
+		  "id": 41,
+		  "iid": 1,
+		  "project_id": 4,
+		  "title": "Something is broken",
+		  "description": "steps to reproduce",
+		  "state": "opened",
+		  "type": "ISSUE",
+		  "issue_type": "issue",
+		  "severity": "UNKNOWN",
+		  "health_status": "on_track",
+		  "confidential": false,
+		  "discussion_locked": null,
+		  "merge_requests_count": 2,
+		  "user_notes_count": 7,
+		  "web_url": "https://gitlab.example.com/group/project/-/issues/1",
+		  "created_at": "2026-01-04T15:31:51.081Z",
+		  "updated_at": "2026-02-11T10:12:00.000Z",
+		  "labels": ["bug", "ui"],
+		  "references": {
+		    "short": "#1",
+		    "relative": "#1",
+		    "full": "group/project#1"
+		  },
+		  "author": { "id": 3, "name": "Author", "username": "author", "state": "active", "avatar_url": "", "web_url": "" }
+		}
+		""";
+
+	[Test]
+	public void Parse_WorkItemPayload_PopulatesNewFields()
+	{
+		var issue = JsonSerializer.Deserialize<Issue>(WorkItemJson);
+
+		Assert.That(issue,                Is.Not.Null);
+		Assert.That(issue!.Id,            Is.EqualTo(41));
+		Assert.That(issue.Iid,            Is.EqualTo(1));
+		Assert.That(issue.IssueType,      Is.EqualTo(WorkItemType.Issue));
+		Assert.That(issue.Type,           Is.EqualTo(WorkItemType.Issue));
+		Assert.That(issue.EffectiveType,  Is.EqualTo(WorkItemType.Issue));
+		Assert.That(issue.Severity,       Is.EqualTo("UNKNOWN"));
+		Assert.That(issue.HealthStatus,   Is.EqualTo("on_track"));
+		Assert.That(issue.MergeRequestsCount, Is.EqualTo(2));
+		Assert.That(issue.DiscussionLocked,   Is.Null);
+		Assert.That(issue.References,         Is.Not.Null);
+		Assert.That(issue.References!.Full,   Is.EqualTo("group/project#1"));
+		Assert.That(issue.References.ToString(), Is.EqualTo("group/project#1"));
+	}
+
+	[TestCase(@"issue",       WorkItemType.Issue)]
+	[TestCase(@"incident",    WorkItemType.Incident)]
+	[TestCase(@"test_case",   WorkItemType.TestCase)]
+	[TestCase(@"task",        WorkItemType.Task)]
+	[TestCase(@"epic",        WorkItemType.Epic)]
+	[TestCase(@"objective",   WorkItemType.Objective)]
+	[TestCase(@"key_result",  WorkItemType.KeyResult)]
+	[TestCase(@"requirement", WorkItemType.Requirement)]
+	[TestCase(@"ticket",      WorkItemType.Ticket)]
+	public void Parse_LowerSnakeCaseIssueType(string wire, WorkItemType expected)
+	{
+		var issue = JsonSerializer.Deserialize<Issue>($$"""{ "issue_type": "{{wire}}" }""")!;
+		Assert.That(issue.IssueType, Is.EqualTo(expected));
+	}
+
+	[TestCase(@"ISSUE",     WorkItemType.Issue)]
+	[TestCase(@"TEST_CASE", WorkItemType.TestCase)]
+	[TestCase(@"KEY_RESULT", WorkItemType.KeyResult)]
+	public void Parse_UpperSnakeCaseType(string wire, WorkItemType expected)
+	{
+		var issue = JsonSerializer.Deserialize<Issue>($$"""{ "type": "{{wire}}" }""")!;
+		Assert.That(issue.Type, Is.EqualTo(expected));
+	}
+
+	[Test]
+	public void Parse_UnknownWorkItemType_DoesNotThrow()
+	{
+		var issue = JsonSerializer.Deserialize<Issue>("""{ "iid": 5, "issue_type": "brand_new_type" }""");
+
+		Assert.That(issue,           Is.Not.Null);
+		Assert.That(issue!.Iid,      Is.EqualTo(5));
+		Assert.That(issue.IssueType, Is.EqualTo(WorkItemType.Unknown));
+	}
+
+	[Test]
+	public void Parse_MissingType_IsUnknown()
+	{
+		var issue = JsonSerializer.Deserialize<Issue>("""{ "iid": 5 }""")!;
+		Assert.That(issue.IssueType,     Is.EqualTo(WorkItemType.Unknown));
+		Assert.That(issue.EffectiveType, Is.EqualTo(WorkItemType.Unknown));
+	}
+
+	[Test]
+	public void Parse_NullType_IsUnknown()
+	{
+		var issue = JsonSerializer.Deserialize<Issue>("""{ "iid": 5, "issue_type": null }""")!;
+		Assert.That(issue.IssueType, Is.EqualTo(WorkItemType.Unknown));
+	}
+
+	[Test]
+	public void EffectiveType_FallsBackToTypeField()
+	{
+		var issue = JsonSerializer.Deserialize<Issue>("""{ "type": "INCIDENT" }""")!;
+		Assert.That(issue.IssueType,     Is.EqualTo(WorkItemType.Unknown));
+		Assert.That(issue.EffectiveType, Is.EqualTo(WorkItemType.Incident));
+	}
+
+	[TestCase(@"opened",   IssueState.Opened)]
+	[TestCase(@"reopened", IssueState.Opened)]
+	[TestCase(@"closed",   IssueState.Closed)]
+	[TestCase(@"CLOSED",   IssueState.Closed)]
+	public void Parse_KnownStates(string wire, IssueState expected)
+	{
+		var issue = JsonSerializer.Deserialize<Issue>($$"""{ "state": "{{wire}}" }""")!;
+		Assert.That(issue.State, Is.EqualTo(expected));
+	}
+
+	[Test]
+	public void Parse_UnknownState_DoesNotAbortTheWholePage()
+	{
+		var json = """[{ "iid": 1, "state": "some_future_state" }, { "iid": 2, "state": "opened" }]""";
+
+		var issues = JsonSerializer.Deserialize<Issue[]>(json);
+
+		Assert.That(issues,       Is.Not.Null);
+		Assert.That(issues!,      Has.Length.EqualTo(2));
+		Assert.That(issues[0].State, Is.EqualTo(IssueState.Unknown));
+		Assert.That(issues[1].State, Is.EqualTo(IssueState.Opened));
+	}
+
+	[Test]
+	public void Parse_UnknownMilestoneState_DoesNotThrow()
+	{
+		var issue = JsonSerializer.Deserialize<Issue>(
+			"""{ "iid": 1, "milestone": { "id": 1, "title": "v1", "state": "brand_new" } }""")!;
+
+		Assert.That(issue.Milestone,        Is.Not.Null);
+		Assert.That(issue.Milestone!.Title, Is.EqualTo("v1"));
+		Assert.That(issue.Milestone.State,  Is.EqualTo(MilestoneState.Unknown));
+	}
+
+	[Test]
+	public void Parse_IdentifiersBeyondInt32_AreNotTruncated()
+	{
+		var issue = JsonSerializer.Deserialize<Issue>("""{ "id": 4294967296, "iid": 3, "project_id": 3000000000 }""")!;
+
+		Assert.That(issue.Id,        Is.EqualTo(4294967296L));
+		Assert.That(issue.ProjectId, Is.EqualTo(3000000000L));
+	}
+}

--- a/tests/gitter.tests.prj/GitLab/LabelsFilterModelTests.cs
+++ b/tests/gitter.tests.prj/GitLab/LabelsFilterModelTests.cs
@@ -1,0 +1,224 @@
+#region Copyright Notice
+/*
+ * gitter - VCS repository management tool
+ * Copyright (C) 2013  Popovskiy Maxim Vladimirovitch <amgine.gitter@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#endregion
+
+#nullable enable
+
+namespace gitter.GitLab.Gui;
+
+using System.Linq;
+
+using NUnit.Framework;
+
+using Label = gitter.GitLab.Api.Label;
+
+[TestFixture]
+class LabelsFilterModelTests
+{
+	private static Label L(string name, string? description = null)
+		=> new() { Name = name, Color = "#000000", Description = description };
+
+	private static LabelsFilterModel WithLabels(params Label[] labels)
+		=> new() { Labels = labels };
+
+	private static string[] Names(LabelsFilterModel model, string? filter)
+		=> model.GetVisibleLabels(filter).Select(static l => l.Name).ToArray();
+
+	#region filtering
+
+	[Test]
+	public void EmptyFilter_ShowsEverything()
+	{
+		var model = WithLabels(L("bug"), L("ui"), L("backend"));
+		Assert.That(Names(model, null),   Is.EqualTo(new[] { "bug", "ui", "backend" }));
+		Assert.That(Names(model, ""),     Is.EqualTo(new[] { "bug", "ui", "backend" }));
+		Assert.That(Names(model, "   "),  Is.EqualTo(new[] { "bug", "ui", "backend" }));
+	}
+
+	[Test]
+	public void Filter_MatchesSubstringCaseInsensitively()
+	{
+		var model = WithLabels(L("Bug"), L("debug"), L("ui"));
+		Assert.That(Names(model, "bug"), Is.EqualTo(new[] { "Bug", "debug" }));
+		Assert.That(Names(model, "BUG"), Is.EqualTo(new[] { "Bug", "debug" }));
+	}
+
+	[Test]
+	public void Filter_MatchesDescriptionToo()
+	{
+		var model = WithLabels(L("p1", "highest priority"), L("p2", "normal"));
+		Assert.That(Names(model, "priority"), Is.EqualTo(new[] { "p1" }));
+	}
+
+	[Test]
+	public void Filter_IsTrimmed()
+	{
+		var model = WithLabels(L("bug"), L("ui"));
+		Assert.That(Names(model, "  bug  "), Is.EqualTo(new[] { "bug" }));
+	}
+
+	[Test]
+	public void Filter_NoMatch_ReturnsEmpty()
+	{
+		var model = WithLabels(L("bug"), L("ui"));
+		Assert.That(Names(model, "zzz"), Is.Empty);
+	}
+
+	[Test]
+	public void Filter_PreservesRegistryOrder()
+	{
+		var model = WithLabels(L("zeta"), L("alpha"), L("zulu"));
+		Assert.That(Names(model, "z"), Is.EqualTo(new[] { "zeta", "zulu" }));
+	}
+
+	[Test]
+	public void Labels_NullResetsToEmpty()
+	{
+		var model = WithLabels(L("bug"));
+		model.Labels = null!;
+		Assert.That(model.GetVisibleLabels(null), Is.Empty);
+	}
+
+	[Test]
+	public void Matches_NullLabel_IsFalse()
+	{
+		Assert.That(LabelsFilterModel.Matches(null, null), Is.False);
+	}
+
+	#endregion
+
+	#region selection
+
+	[Test]
+	public void Select_TogglesMembership()
+	{
+		var model = WithLabels(L("bug"), L("ui"));
+
+		Assert.That(model.Select("bug", selected: true), Is.True);
+		Assert.That(model.IsSelected("bug"),             Is.True);
+		Assert.That(model.SelectedCount,                 Is.EqualTo(1));
+
+		Assert.That(model.Select("bug", selected: false), Is.True);
+		Assert.That(model.IsSelected("bug"),              Is.False);
+		Assert.That(model.SelectedCount,                  Is.EqualTo(0));
+	}
+
+	[Test]
+	public void Select_RedundantChange_ReportsNoChange()
+	{
+		var model = WithLabels(L("bug"));
+
+		model.Select("bug", selected: true);
+		Assert.That(model.Select("bug", selected: true),   Is.False);
+		Assert.That(model.Select("ui",  selected: false),  Is.False);
+	}
+
+	[Test]
+	public void Select_IgnoresEmptyName()
+	{
+		var model = WithLabels(L("bug"));
+		Assert.That(model.Select("", selected: true), Is.False);
+		Assert.That(model.SelectedCount,              Is.EqualTo(0));
+	}
+
+	[Test]
+	public void Selection_SurvivesFilteringTheLabelOutOfView()
+	{
+		var model = WithLabels(L("bug"), L("ui"));
+		model.Select("bug", selected: true);
+
+		Assert.That(Names(model, "ui"),      Is.EqualTo(new[] { "ui" }));
+		Assert.That(model.IsSelected("bug"), Is.True);
+		Assert.That(model.Selected,          Is.EquivalentTo(new[] { "bug" }));
+	}
+
+	[Test]
+	public void Selection_SurvivesLabelListReplacement()
+	{
+		var model = WithLabels(L("bug"), L("ui"));
+		model.Select("bug", selected: true);
+
+		model.Labels = new[] { L("bug"), L("ui"), L("backend") };
+
+		Assert.That(model.IsSelected("bug"), Is.True);
+	}
+
+	[Test]
+	public void Selection_KeepsLabelsMissingFromTheRegistry()
+	{
+		var model = WithLabels(L("bug"));
+		model.SetSelected(new[] { "bug", "removed-upstream" });
+
+		Assert.That(model.Selected, Is.EquivalentTo(new[] { "bug", "removed-upstream" }));
+	}
+
+	[Test]
+	public void SetSelected_ReplacesPreviousSelection()
+	{
+		var model = WithLabels(L("bug"), L("ui"));
+		model.Select("bug", selected: true);
+
+		model.SetSelected(new[] { "ui" });
+
+		Assert.That(model.Selected, Is.EquivalentTo(new[] { "ui" }));
+	}
+
+	[Test]
+	public void SetSelected_Null_ClearsSelection()
+	{
+		var model = WithLabels(L("bug"));
+		model.Select("bug", selected: true);
+
+		model.SetSelected(null);
+
+		Assert.That(model.SelectedCount, Is.EqualTo(0));
+	}
+
+	[Test]
+	public void SetSelected_SkipsEmptyNames()
+	{
+		var model = WithLabels(L("bug"));
+		model.SetSelected(new[] { "bug", "", null! });
+
+		Assert.That(model.Selected, Is.EquivalentTo(new[] { "bug" }));
+	}
+
+	[Test]
+	public void SelectionIsCaseSensitive()
+	{
+		var model = WithLabels(L("Bug"), L("bug"));
+		model.Select("Bug", selected: true);
+
+		Assert.That(model.IsSelected("Bug"), Is.True);
+		Assert.That(model.IsSelected("bug"), Is.False);
+	}
+
+	[Test]
+	public void Clear_DropsEverythingAndReportsChange()
+	{
+		var model = WithLabels(L("bug"), L("ui"));
+		model.SetSelected(new[] { "bug", "ui" });
+
+		Assert.That(model.Clear(),       Is.True);
+		Assert.That(model.SelectedCount, Is.EqualTo(0));
+		Assert.That(model.Clear(),       Is.False);
+	}
+
+	#endregion
+}

--- a/tests/gitter.tests.prj/GitLab/RemoteUrlParserTests.cs
+++ b/tests/gitter.tests.prj/GitLab/RemoteUrlParserTests.cs
@@ -1,0 +1,297 @@
+#region Copyright Notice
+/*
+ * gitter - VCS repository management tool
+ * Copyright (C) 2013  Popovskiy Maxim Vladimirovitch <amgine.gitter@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#endregion
+
+#nullable enable
+
+namespace gitter.GitLab;
+
+using System;
+
+using NUnit.Framework;
+
+[TestFixture]
+class RemoteUrlParserTests
+{
+	private static readonly Uri GitLabCom = new(@"https://gitlab.com/");
+
+	private static string? Parse(string remote, string service = @"https://gitlab.com/")
+		=> RemoteUrlParser.TryGetProjectPath(new Uri(service), remote, out var path) ? path : null;
+
+	#region .git suffix
+
+	[Test]
+	public void Https_StripsDotGitSuffix()
+	{
+		Assert.That(Parse(@"https://gitlab.com/group/project.git"), Is.EqualTo(@"group/project"));
+	}
+
+	[Test]
+	public void Https_WithoutDotGitSuffix_IsUnchanged()
+	{
+		Assert.That(Parse(@"https://gitlab.com/group/project"), Is.EqualTo(@"group/project"));
+	}
+
+	[Test]
+	public void Https_StripsDotGitSuffixWithTrailingSlash()
+	{
+		Assert.That(Parse(@"https://gitlab.com/group/project.git/"), Is.EqualTo(@"group/project"));
+	}
+
+	[Test]
+	public void Https_StripsTrailingSlash()
+	{
+		Assert.That(Parse(@"https://gitlab.com/group/project/"), Is.EqualTo(@"group/project"));
+	}
+
+	[Test]
+	public void Ssh_ScpLike_StripsDotGitSuffix()
+	{
+		Assert.That(Parse(@"git@gitlab.com:group/project.git"), Is.EqualTo(@"group/project"));
+	}
+
+	[Test]
+	public void Ssh_Url_StripsDotGitSuffix()
+	{
+		Assert.That(Parse(@"ssh://git@gitlab.com/group/project.git"), Is.EqualTo(@"group/project"));
+	}
+
+	[Test]
+	public void Ssh_UrlWithNonDefaultPort_StripsDotGitSuffix()
+	{
+		Assert.That(Parse(@"ssh://git@gitlab.com:2222/group/project.git"), Is.EqualTo(@"group/project"));
+	}
+
+	[Test]
+	public void Git_Protocol_StripsDotGitSuffix()
+	{
+		Assert.That(Parse(@"git://gitlab.com/group/project.git"), Is.EqualTo(@"group/project"));
+	}
+
+	#endregion
+
+	#region nested namespaces
+
+	[Test]
+	public void Https_KeepsNestedSubgroups()
+	{
+		Assert.That(Parse(@"https://gitlab.com/group/sub/deeper/project.git"),
+			Is.EqualTo(@"group/sub/deeper/project"));
+	}
+
+	[Test]
+	public void ScpLike_KeepsNestedSubgroups()
+	{
+		Assert.That(Parse(@"git@gitlab.com:group/sub/deeper/project.git"),
+			Is.EqualTo(@"group/sub/deeper/project"));
+	}
+
+	[Test]
+	public void ScpLike_LeadingSlashAfterColonIsIgnored()
+	{
+		Assert.That(Parse(@"git@gitlab.com:/group/project.git"), Is.EqualTo(@"group/project"));
+	}
+
+	#endregion
+
+	#region real world shapes
+
+	private const string Nested = @"promcontrol/viscont/nugets/viscont.core.framework.sparkpulse";
+	private const string Mallenom = @"https://gitlab.mallenom.dev/";
+
+	[Test]
+	public void Nested_Https_WithDotGit()
+	{
+		Assert.That(Parse($@"{Mallenom}{Nested}.git", Mallenom), Is.EqualTo(Nested));
+	}
+
+	[Test]
+	public void Nested_Https_WithoutDotGit()
+	{
+		Assert.That(Parse($@"{Mallenom}{Nested}", Mallenom), Is.EqualTo(Nested));
+	}
+
+	[Test]
+	public void Nested_ScpLike()
+	{
+		Assert.That(Parse($@"git@gitlab.mallenom.dev:{Nested}.git", Mallenom), Is.EqualTo(Nested));
+	}
+
+	[Test]
+	public void Nested_Ssh()
+	{
+		Assert.That(Parse($@"ssh://git@gitlab.mallenom.dev/{Nested}.git", Mallenom), Is.EqualTo(Nested));
+	}
+
+	[Test]
+	public void DotsInProjectName_AreNotMistakenForTheDotGitSuffix()
+	{
+		Assert.That(Parse($@"{Mallenom}{Nested}.git", Mallenom),
+			Does.EndWith(@"viscont.core.framework.sparkpulse"));
+	}
+
+	[Test]
+	public void HttpsRemote_DoesNotMatchAnHttpServerEntryOnTheSameHost()
+	{
+		Assert.That(Parse($@"{Mallenom}{Nested}.git", @"http://gitlab.mallenom.dev/"), Is.Null);
+	}
+
+	[Test]
+	public void HttpRemote_DoesNotMatchAnHttpsServerEntryOnTheSameHost()
+	{
+		Assert.That(Parse($@"http://gitlab.mallenom.dev/{Nested}.git", Mallenom), Is.Null);
+	}
+
+	[Test]
+	public void ScpLikeRemote_MatchesEitherSchemeOfTheSameHost()
+	{
+		Assert.That(Parse($@"git@gitlab.mallenom.dev:{Nested}.git", Mallenom),                    Is.EqualTo(Nested));
+		Assert.That(Parse($@"git@gitlab.mallenom.dev:{Nested}.git", @"http://gitlab.mallenom.dev/"), Is.EqualTo(Nested));
+	}
+
+	#endregion
+
+	#region noise the old implementation kept
+
+	[Test]
+	public void Https_DropsQueryString()
+	{
+		Assert.That(Parse(@"https://gitlab.com/group/project.git?ref=main"), Is.EqualTo(@"group/project"));
+	}
+
+	[Test]
+	public void Https_DropsFragment()
+	{
+		Assert.That(Parse(@"https://gitlab.com/group/project.git#anchor"), Is.EqualTo(@"group/project"));
+	}
+
+	[Test]
+	public void Https_DropsUserInfo()
+	{
+		Assert.That(Parse(@"https://oauth2:token@gitlab.com/group/project.git"), Is.EqualTo(@"group/project"));
+	}
+
+	[Test]
+	public void Https_UnescapesPercentEncodedPath()
+	{
+		Assert.That(Parse(@"https://gitlab.com/my%20group/project.git"), Is.EqualTo(@"my group/project"));
+	}
+
+	[Test]
+	public void SurroundingWhitespaceIsIgnored()
+	{
+		Assert.That(Parse("  https://gitlab.com/group/project.git\t"), Is.EqualTo(@"group/project"));
+	}
+
+	#endregion
+
+	#region self-hosted with relative url root
+
+	[Test]
+	public void Https_StripsServiceUriBasePath()
+	{
+		Assert.That(Parse(@"https://host.example.com/gitlab/group/project.git", @"https://host.example.com/gitlab/"),
+			Is.EqualTo(@"group/project"));
+	}
+
+	[Test]
+	public void Https_ServiceUriBasePathWithoutTrailingSlash_IsStripped()
+	{
+		Assert.That(Parse(@"https://host.example.com/gitlab/group/project.git", @"https://host.example.com/gitlab"),
+			Is.EqualTo(@"group/project"));
+	}
+
+	[Test]
+	public void ScpLike_DoesNotStripServiceUriBasePath()
+	{
+		Assert.That(Parse(@"git@host.example.com:group/project.git", @"https://host.example.com/gitlab/"),
+			Is.EqualTo(@"group/project"));
+	}
+
+	#endregion
+
+	#region host matching
+
+	[Test]
+	public void HostComparisonIsCaseInsensitive()
+	{
+		Assert.That(Parse(@"https://GitLab.COM/group/project.git"), Is.EqualTo(@"group/project"));
+	}
+
+	[Test]
+	public void ScpLikeHostComparisonIsCaseInsensitive()
+	{
+		Assert.That(Parse(@"git@GitLab.COM:group/project.git"), Is.EqualTo(@"group/project"));
+	}
+
+	[Test]
+	public void ForeignHost_IsRejected()
+	{
+		Assert.That(Parse(@"https://github.com/group/project.git"), Is.Null);
+	}
+
+	[Test]
+	public void ForeignHost_ScpLike_IsRejected()
+	{
+		Assert.That(Parse(@"git@github.com:group/project.git"), Is.Null);
+	}
+
+	[Test]
+	public void Https_NonMatchingPort_IsRejected()
+	{
+		Assert.That(Parse(@"https://gitlab.com:8443/group/project.git"), Is.Null);
+	}
+
+	[Test]
+	public void Https_MatchingNonDefaultPort_IsAccepted()
+	{
+		Assert.That(Parse(@"https://gitlab.com:8443/group/project.git", @"https://gitlab.com:8443/"),
+			Is.EqualTo(@"group/project"));
+	}
+
+	[Test]
+	public void Ssh_PortIsNotComparedAgainstHttpsServicePort()
+	{
+		Assert.That(Parse(@"ssh://git@gitlab.com:22/group/project.git"), Is.EqualTo(@"group/project"));
+	}
+
+	#endregion
+
+	#region rejected input
+
+	[TestCase(@"")]
+	[TestCase(@"   ")]
+	[TestCase(@"https://gitlab.com/")]
+	[TestCase(@"https://gitlab.com/.git")]
+	[TestCase(@"git@gitlab.com:")]
+	[TestCase(@"D:\repos\project")]
+	[TestCase(@"../relative/path")]
+	public void MalformedOrEmpty_IsRejected(string remote)
+	{
+		Assert.That(RemoteUrlParser.TryGetProjectPath(GitLabCom, remote, out _), Is.False);
+	}
+
+	[Test]
+	public void Null_IsRejected()
+	{
+		Assert.That(RemoteUrlParser.TryGetProjectPath(GitLabCom, null, out _), Is.False);
+	}
+
+	#endregion
+}


### PR DESCRIPTION
Fixes GitLab issue fetching, which broke for projects cloned over HTTPS, and modernizes the plugin for GitLab's move to work items. Also reworks the labels filter and hardens the API layer.